### PR TITLE
Add .bundle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 access_token
 .DS_Store
+.bundle


### PR DESCRIPTION
This just allows you to run `bundle install` in the example directories without incurring an untracked `.bundle/` directory.
