### PR TITLE
Refactor shell scripts

### DIFF
--- a/api/bash/README.md
+++ b/api/bash/README.md
@@ -1,12 +1,42 @@
 This directory contains small scripts that demonstrate some basic uses of the GitHub API.
 
+## Getting Started
+Many of these bash scripts require a GitHub Token to authenticate your usage of certain API features. 
+
 ## Details
 Below are brief explanations of each script's functionality, along with instructions on how to use them.
+
+### set-status 
+
+#### What is it?
+`set-status` will [create a status for a given Ref](https://developer.github.com/v3/repos/statuses/#create-a-status) in a repository.
+
+#### Usage
+*Note: you will need to have push access to any repository you wish to run `set-status` on.*
+
+```
+./set-status owner/repository SHA '{"state": "success", "target_url": "https://example.com/build/status", "description": "The build succeeded!", "context": "continuous-integration/jenkins"}'
+```
+Where `SHA` is the full 40 character commit identifier.
+
+### get-status
+
+#### What is it?
+`get-status` will [retrieve status for a particular Ref](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref) in a repository.
+
+#### Usage
+```
+./get-status owner/repository ref
+```
+Where `ref` is either a SHA, branch name, or tag name.
 
 ### pretty-print
 
 #### What is it?
 `pretty-print` displays formatted, colorized summaries of GitHub users and repositories. Quickly grab stats, get a sense of project activiy, and display clone URLs, all without leaving the command line.
+
+#### Dependencies
+`pretty-print` uses the [jq](http://stedolan.github.io/jq/) JSON processor. Mac users can easily install it with [Homebrew](http://brew.sh): ` brew install jq `
 
 #### Usage
 *Note: `pretty-print` accepts a full GitHub username or repo URL as valid input for all commands.*
@@ -24,8 +54,6 @@ Options:
  -h | --help                      Help
  ```
 
-#### Dependencies
-`pretty-print` uses the [jq](http://stedolan.github.io/jq/) JSON processor. Mac users can easily install it with [Homebrew](http://brew.sh): ` brew install jq `
 
 ## API Documentation
 The full documentation for the GitHub API is [available here](http://developer.github.com).

--- a/api/bash/README.md
+++ b/api/bash/README.md
@@ -3,25 +3,29 @@ This directory contains small scripts that demonstrate some basic uses of the Gi
 ## Details
 Below are brief explanations of each script's functionality, along with instructions on how to use them.
 
-### pretty-print.sh
+### pretty-print
 
 #### What is it?
-`pretty-print.sh` displays formatted, colorized summaries of GitHub users and repositories. Quickly grab stats, get a sense of project activiy, and display clone URLs, all without leaving the command line.
+`pretty-print` displays formatted, colorized summaries of GitHub users and repositories. Quickly grab stats, get a sense of project activiy, and display clone URLs, all without leaving the command line.
 
 #### Usage
-*Note: `pretty-print.sh` accepts a full GitHub username or repo URL as valid input for all commands. Also, remember to make it executable: `chmod +x pretty-print.sh`.*
+*Note: `pretty-print` accepts a full GitHub username or repo URL as valid input for all commands.*
 
-Display summary of a user:
-`./pretty-print.sh -u <username>`
+Display help text: 
+`./pretty-print -h`
 
-Display a summary of a repository:
-`./pretty-print.sh -r <username/repositoryname>`
+```
+Usage: ./pretty-print [options] <argv>...
 
-Display list of forks for a GitHub repository:
-`./pretty-print.sh -f <username/repositoryname>`
+Options:
+ -f | --forks <user/repository>   Display list of forks for a  repository
+ -r | --repo  <user/repository>   Display a summary of a repository
+ -u | --user  <username>          Display summary of a user
+ -h | --help                      Help
+ ```
 
 #### Dependencies
-This script uses the [jq](http://stedolan.github.io/jq/) JSON processor. Mac users can easily install it with [Homebrew](http://brew.sh): ` brew install jq `
+`pretty-print` uses the [jq](http://stedolan.github.io/jq/) JSON processor. Mac users can easily install it with [Homebrew](http://brew.sh): ` brew install jq `
 
 ## API Documentation
 The full documentation for the GitHub API is [available here](http://developer.github.com).

--- a/api/bash/README.md
+++ b/api/bash/README.md
@@ -1,9 +1,16 @@
 This directory contains small scripts that demonstrate some basic uses of the GitHub API.
 
 ## Getting Started
-Many of these bash scripts require a GitHub Token to authenticate your usage of certain API features. 
+Many of these bash scripts require a GitHub Token to authenticate your usage of certain API features. You may [generate a new API token Here](https://github.com/settings/tokens/new). 
 
-## Details
+Once you have a valid token, you may temporarily add it as an environmental variable by running the following in your terminal window:
+
+```
+export GH_TOKEN='YOUR_GITHUB_TOKEN_GOES_HERE'
+```
+
+**Remember:** Your GitHub Token is like a password. *Never commit your token to a repository*. 
+
 Below are brief explanations of each script's functionality, along with instructions on how to use them.
 
 ### set-status 
@@ -12,7 +19,7 @@ Below are brief explanations of each script's functionality, along with instruct
 `set-status` will [create a status for a given Ref](https://developer.github.com/v3/repos/statuses/#create-a-status) in a repository.
 
 #### Usage
-*Note: you will need to have push access to any repository you wish to run `set-status` on.*
+*Note: you will need push access to any repository you wish to use with `set-status`.*
 
 ```
 ./set-status owner/repository SHA '{"state": "success", "target_url": "https://example.com/build/status", "description": "The build succeeded!", "context": "continuous-integration/jenkins"}'

--- a/api/bash/get-status
+++ b/api/bash/get-status
@@ -4,9 +4,6 @@
 
 # $1 = username/repo
 # $2 = ref
-postStatus()
-{
-  github_get "repos/$1/commits/$2/status"
-}
 
-postStatus "$@"
+github_get "repos/$1/commits/$2/status"
+

--- a/api/bash/get-status
+++ b/api/bash/get-status
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+. plumbing
+
+# $1 = username/repo
+# $2 = ref
+postStatus()
+{
+  github_get "repos/$1/commits/$2/status"
+}
+
+postStatus "$@"

--- a/api/bash/plumbing
+++ b/api/bash/plumbing
@@ -1,6 +1,8 @@
 # building block, not intended for use by end-user
 # $1 = endpoint, e.g. users/defunkt
 # any remaining args = curl options
+
+# Usage: callAPI "repos/$1/statuses/$2" -d "$3"
 callAPI()
 {
   local AUTH="Authorization: token $GH_TOKEN"
@@ -9,4 +11,18 @@ callAPI()
   shift
 
   curl -i -H "$AUTH" "$@" "$REQUEST_URL"
+}
+
+# Usage: github_get repo/$1/statues/$2
+# Purpose: Make a curl -s Silent -G Get request
+github_get()
+{
+  local request_route=$@
+
+  if [ -n "$GH_TOKEN" ]
+  then
+    curl -s -G "https://api.github.com/$request_route" -H "User-Agent: github/platform-samples" -H "Accept: application/vnd.github.full+json" -H "Authorization: token $GH_TOKEN"
+  else
+    curl -s -G "https://api.github.com/$request_route" -H "User-Agent: github/platform-samples" -H "Accept: application/vnd.github.full+json"
+  fi
 }

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -2,8 +2,17 @@
 
 # set -x # for debugging
 
-
-GH_TOKEN=""
+# TODO replace with plumbing
+gh_request()
+{
+  local gh_request_route=$@
+  if [ -n "$GH_TOKEN" ]
+  then
+    curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json" -H "Authorization: token $GH_TOKEN"
+  else
+    curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json"
+  fi
+}
 
 #### COLORS & FORMATTING
 
@@ -25,23 +34,58 @@ _target=${_magenta}
 _em=${_blue}${_bold}
 
 
-#### CORE FUNCTIONS
+##### META 
 
-gh_request()
+dependency_test()
 {
-  local gh_request_route=$@
-  if [ -n "$GH_TOKEN" ]
-  then
-    curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json" -H "Authorization: token $GH_TOKEN"
-  else
-    curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json"
-  fi
+  for dep in curl jq ; do
+    command -v $dep &>/dev/null || { echo -e "\n${_error}Error:${_reset} I require the ${_command}$dep${_reset} command but it's not installed.\n"; exit 1; }
+  done
 }
+
+usage()
+{
+  echo -e "Usage: $0 [options] <argv>...\n"
+  echo "Options:"
+  echo " -f | --forks <user/repository>   Display fork details"
+  echo " -r | --repo  <user/repository>   Display repo details"
+  echo " -u | --user  <username>          Display user details"
+  echo " -t | --token <token>             Set a GitHub token"
+  echo " -h | --help                      Help"
+  echo ""
+}
+
+
+#### HELPERS - to reduce duplication
+
+set_user_context()
+{
+  context=$(echo "$1" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's#/$## ')
+}
+set_repo_context()
+{
+  context=$(echo "$1" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's/\.*git$//' -e 's#/$##')
+}
+
+print_header(){
+
+  local name_length=${#context}
+  local header_length=$(( name_length + 13 ))
+  
+  echo -e "\nDetails for ${_target}$context${_reset}:"
+  for i in $(seq 1 $header_length); do
+    echo -n "="
+  done
+  echo -e "\n"
+  
+}
+
+#### CORE FUNCTIONS
 
 api_request()
 {
   local api_request_result=$( gh_request "$1") # only make a single API request
-  shift
+  shift # Shift 
 
   api_request_filtered=() # initialize/empty filtered results array
 
@@ -66,50 +110,33 @@ api_request_forks() # FIXME: refactor this into the main api_request function
 
 }
 
-dependency_test()
-{
-  for dep in curl jq ; do
-    command -v $dep &>/dev/null || { echo -e "\n${_error}Error:${_reset} I require the ${_command}$dep${_reset} command but it's not installed.\n"; exit 1; }
-  done
-}
-
-usage()
-{
-  echo -e "Usage: $0 [options] <argv>...\n"
-  echo "Options:"
-  echo " -u | --user <username>           Display user details"
-  echo " -r | --repo <user/repository>    Display repo details"
-  echo " -h | --help                      Help"
-  echo ""
-}
 
 #### FORMATTED REQUEST FUNCTIONS
 #    Uses format: `api_request 'API_ROUTE' 'FILTER1' 'FILTER2' ...`
 
 user_details()
 {
-  local cleaned_username=$(echo "${username}" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's#/$## ')
-  echo -e "\nDetails for GitHub user ${_magenta}$cleaned_username${_reset}:"
-  local name_length=${#cleaned_username}
+  print_header 
+
+  local name_length=${#context}
   local header_length=$(( name_length + 25 ))
-  for i in $(seq 1 $header_length); do
-    echo -n "="
-  done
-  echo -e "\n"
-  api_request "users/$cleaned_username" '.name' '.location' '.email' '.bio' '.public_repos' '.public_gists' '.followers' '.following' '.created_at'
+  
+  api_request "users/$context" '.name' '.location' '.email' '.bio' '.public_repos' '.public_gists' '.followers' '.following' '.created_at'
+
   echo "     Name: ${api_request_filtered[0]}"
   echo " Location: ${api_request_filtered[1]}"
   local email=${api_request_filtered[2]}
+  local bio=${api_request_filtered[3]}
+  local user_since=${api_request_filtered[8]}
+  
   if [ $email != "null" ]; then
     echo "    Email: $email"
   fi
-  local bio=${api_request_filtered[3]}
   if [ "$bio" != "null" ]; then
     echo "      Bio: $bio"
   fi
   echo -e "\n"
-  echo -e " ${_magenta}$cleaned_username${_reset} has shared ${_em}${api_request_filtered[4]}${_reset} public git repositories and ${_em}${api_request_filtered[5]}${_reset} gists.\n"
-  local user_since=${api_request_filtered[8]}
+  echo -e " ${_magenta}$context${_reset} has shared ${_em}${api_request_filtered[4]}${_reset} public git repositories and ${_em}${api_request_filtered[5]}${_reset} gists.\n"
   for i in $(seq 1 $name_length); do
     echo -n " "
   done
@@ -123,26 +150,26 @@ user_details()
 
 repo_details()
 {
-  local cleaned_repo=$(echo "${repo}" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's/\.*git$//' -e 's#/$##')
-  echo -e "\nDetails for repository ${_target}$cleaned_repo${_reset}:"
-  local name_length=${#cleaned_repo}
-  local header_length=$(( name_length + 24 ))
-  for i in $(seq 1 $header_length); do
-    echo -n "="
-  done
-  echo -e "\n"
-  api_request "repos/$cleaned_repo" '.name' '.owner.login' '.description' '.forks_count' '.stargazers_count' '.open_issues_count' '.created_at' '.updated_at' '.parent.name' '.parent.owner.login' '.clone_url' '.homepage'
-  echo -e " ${_bold}${_white}${api_request_filtered[0]}${_reset} by ${api_request_filtered[1]}\n"
+  print_header 
+
+  api_request "repos/$context" '.name' '.owner.login' '.description' '.forks_count' '.stargazers_count' '.open_issues_count' '.created_at' '.updated_at' '.parent.name' '.parent.owner.login' '.clone_url' '.homepage'
+
   local description=${api_request_filtered[2]}
+  local created_at=${api_request_filtered[6]}
+  local updated_at=${api_request_filtered[7]}
+  local parent_name=${api_request_filtered[8]}
+  local parent_owner=${api_request_filtered[9]}
+  local homepage=${api_request_filtered[11]} # FIXME: dirty hack because GH returns an empty value instead of null
+
+  echo -e " ${_bold}${_white}${api_request_filtered[0]}${_reset} by ${api_request_filtered[1]}\n"
   if [ "$description" != "null" ]; then
     echo " $description" | fmt
     echo ""
   fi
-  local homepage=${api_request_filtered[11]} # FIXME: dirty hack because GH returns an empty value instead of null
   if [[ -n $homepage ]]; then
     echo " Homepage: $homepage"
   fi
-  echo -e "\n ${_target}$cleaned_repo${_reset} has been forked ${_em}${api_request_filtered[3]}${_reset} times and starred ${_em}${api_request_filtered[4]}${_reset} times.\n"
+  echo -e "\n ${_target}$context${_reset} has been forked ${_em}${api_request_filtered[3]}${_reset} times and starred ${_em}${api_request_filtered[4]}${_reset} times.\n"
   for i in $(seq 1 $name_length); do
     echo -n " "
   done
@@ -150,11 +177,7 @@ repo_details()
   for i in $(seq 1 $name_length); do
     echo -n " "
   done
-  local created_at=${api_request_filtered[6]}
-  local updated_at=${api_request_filtered[7]}
   echo -e "  was created on ${_em}${created_at:0:10}${_reset} and last updated on ${_em}${updated_at:0:10}${_reset}."
-  local parent_name=${api_request_filtered[8]}
-  local parent_owner=${api_request_filtered[9]}
   if [ $parent_name != "null" ]; then
     echo -e "\n\n ${_target}${api_request_filtered[0]}${_reset} was forked from ${_yellow}$parent_name${_yellow} by ${_yellow}$parent_owner${_reset}"
   fi
@@ -165,25 +188,26 @@ repo_details()
 
 list_forks()
 {
-  local cleaned_repo=$(echo "${repo}" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's/\.*git$//' -e 's#/$##')
-  echo -e "\nDetails for repository ${_target}$cleaned_repo${_reset}:"
-  local name_length=${#cleaned_repo}
-  local header_length=$(( name_length + 24 ))
-  for i in $(seq 1 $header_length); do
-    echo -n "="
-  done
-  echo -e "\n"
-  api_request "repos/$cleaned_repo" '.name' '.owner.login' '.forks_count'
+  print_header 
+
+  api_request "repos/$context" '.name' '.owner.login' '.forks_count'
   echo -e "${_bold}${_white}${api_request_filtered[0]}${_reset} by ${api_request_filtered[1]}\n"
-  echo -e "\n${_target}$cleaned_repo${_reset} has been forked ${_em}${api_request_filtered[2]}${_reset} times, including forks by these GitHub users:\n"
-  api_request_forks "repos/$cleaned_repo/forks"
+  echo -e "\n${_target}$context${_reset} has been forked ${_em}${api_request_filtered[2]}${_reset} times, including forks by these GitHub users:\n"
+  api_request_forks "repos/$context/forks"
   echo -e "${_blue}$response${_reset}"
   echo ""
 }
 
+
 #### MAIN
 
 dependency_test
+
+# Print help if no params are passed.
+if [ -z $1 ]; then
+  usage
+  exit 1
+fi
 
 while [ "$1" != "" ]; do
   case $1 in
@@ -192,13 +216,14 @@ while [ "$1" != "" ]; do
     -t | --token )  shift
                     GH_TOKEN="$1" ;;
     -u | --user )   shift
-                    username="$1"
+                    set_user_context "$1"
+                    echo "Context is $context"
                     user_details ;;
     -r | --repo )   shift
-                    repo="$1"
+                    set_repo_context "$1"
                     repo_details ;;
     -f | --forks )  shift
-                    repo="$1"
+                    set_repo_context "$1"
                     list_forks
                     exit ;;
     * )             usage

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -5,22 +5,10 @@
 . plumbing
 
 #### CORE FUNCTIONS
-# TODO replace with plumbing
-
-gh_request()
-{
-  local gh_request_route=$@
-  if [ -n "$GH_TOKEN" ]
-  then
-    curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json" -H "Authorization: token $GH_TOKEN"
-  else
-    curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json"
-  fi
-}
 
 api_request()
 {
-  local api_request_result=$( gh_request "$1") # only make a single API request
+  local api_request_result=$( github_get "$1") # only make a single API request
   shift # Shift 
 
   api_request_filtered=() # initialize/empty filtered results array

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -4,7 +4,9 @@
 
 . plumbing
 
+#### CORE FUNCTIONS
 # TODO replace with plumbing
+
 gh_request()
 {
   local gh_request_route=$@
@@ -15,6 +17,34 @@ gh_request()
     curl -s -G "https://api.github.com/$gh_request_route" -H "User-Agent: nathos/ghinfo" -H "Accept: application/vnd.github.full+json"
   fi
 }
+
+api_request()
+{
+  local api_request_result=$( gh_request "$1") # only make a single API request
+  shift # Shift 
+
+  api_request_filtered=() # initialize/empty filtered results array
+
+  # loop through all requested jq filter arguments
+  for arg in $* ; do
+    _response=$( echo $api_request_result | jq -r "$arg" )
+    if [[ -n $_response ]] ; then
+      api_request_filtered+=("$_response") # append to filtered result array
+    # else
+    #   echo "No response for $arg"
+    fi
+  done
+}
+
+api_request_forks() # FIXME: refactor this into the main api_request function
+{
+  local api_request_result=$( gh_request "$1") # only make a single API request
+
+  api_request_filtered=() # initialize/empty filtered results array
+
+  response=$( echo $api_request_result | jq -r '.[] | .owner.login' )
+}
+
 
 #### COLORS & FORMATTING
 
@@ -64,18 +94,21 @@ set_user_context()
 {
   context=$(echo "$1" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's#/$## ')
 }
+
 set_repo_context()
 {
   context=$(echo "$1" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's/\.*git$//' -e 's#/$##')
 }
 
-print_whitespace(){
+print_whitespace()
+{
   for i in $(seq 1 $1); do
       echo -n " "
   done
 }
 
-print_header(){
+print_header()
+{
   local name_length=${#context}
   local header_length=$(( name_length + 13 ))
   
@@ -86,36 +119,6 @@ print_header(){
   echo -e "\n"
 }
 
-#### CORE FUNCTIONS
-
-api_request()
-{
-  local api_request_result=$( gh_request "$1") # only make a single API request
-  shift # Shift 
-
-  api_request_filtered=() # initialize/empty filtered results array
-
-  # loop through all requested jq filter arguments
-  for arg in $* ; do
-    _response=$( echo $api_request_result | jq -r "$arg" )
-    if [[ -n $_response ]] ; then
-      api_request_filtered+=("$_response") # append to filtered result array
-    # else
-    #   echo "No response for $arg"
-    fi
-  done
-}
-
-api_request_forks() # FIXME: refactor this into the main api_request function
-{
-  local api_request_result=$( gh_request "$1") # only make a single API request
-
-  api_request_filtered=() # initialize/empty filtered results array
-
-  response=$( echo $api_request_result | jq -r '.[] | .owner.login' )
-
-}
-
 
 #### FORMATTED REQUEST FUNCTIONS
 #    Uses format: `api_request 'API_ROUTE' 'FILTER1' 'FILTER2' ...`
@@ -123,35 +126,38 @@ api_request_forks() # FIXME: refactor this into the main api_request function
 user_details()
 {
   print_header 
-
-  local name_length=${#context}
-  
   api_request "users/$context" '.name' '.location' '.email' '.bio' '.public_repos' '.public_gists' '.followers' '.following' '.created_at'
 
-  echo "     Name: ${api_request_filtered[0]}"
-  echo " Location: ${api_request_filtered[1]}"
+  local name_length=${#context}
 
+  local name=${api_request_filtered[0]}
+  local location=${api_request_filtered[1]}
   local email=${api_request_filtered[2]}
   local bio=${api_request_filtered[3]}
+  local public_repos=${api_request_filtered[4]}
+  local public_gists=${api_request_filtered[5]}
+  local followers=${api_request_filtered[6]}
+  local following=${api_request_filtered[7]}
   local user_since=${api_request_filtered[8]}
-  
+
+  echo "     Name: $name"
+  echo " Location: $location"
+
   if [ $email != "null" ]; then
     echo "    Email: $email"
   fi
+
   if [ "$bio" != "null" ]; then
     echo "      Bio: $bio"
   fi
-  echo -e "\n"
-  echo -e " ${_magenta}$context${_reset} has shared ${_em}${api_request_filtered[4]}${_reset} public git repositories and ${_em}${api_request_filtered[5]}${_reset} gists.\n"
-  for i in $(seq 1 $name_length); do
-    echo -n " "
-  done
-  echo -e "  is followed by ${_em}${api_request_filtered[6]}${_reset} GitHub users and follows ${_em}${api_request_filtered[7]}${_reset} users.\n"
-  for i in $(seq 1 $name_length); do
-    echo -n " "
-  done
+
+  echo -e "\n ${_magenta}$context${_reset} has shared ${_em}$public_repos${_reset} public git repositories and ${_em}$public_gists${_reset} gists.\n"
+  print_whitespace $name_length
+
+  echo -e "  is followed by ${_em}$followers${_reset} GitHub users and follows ${_em}$following${_reset} users.\n"
+  print_whitespace $name_length
+
   echo -e "  has been a happy GitHub user since ${_em}${user_since:0:10}${_reset}."
-  echo ""
 }
 
 repo_details()
@@ -190,6 +196,7 @@ repo_details()
   print_whitespace $name_length
 
   echo -e "  was created on ${_em}${created_at:0:10}${_reset} and last updated on ${_em}${updated_at:0:10}${_reset}."
+
   if [ $parent_name != "null" ]; then
     echo -e "\n\n ${_target}$name${_reset} was forked from ${_yellow}$parent_name${_yellow} by ${_yellow}$parent_owner${_reset}"
   fi
@@ -200,8 +207,8 @@ repo_details()
 list_forks()
 {
   print_header 
-
   api_request "repos/$context" '.name' '.owner.login' '.forks_count'
+
   echo -e "${_bold}${_white}${api_request_filtered[0]}${_reset} by ${api_request_filtered[1]}\n"
   echo -e "\n${_target}$context${_reset} has been forked ${_em}${api_request_filtered[2]}${_reset} times, including forks by these GitHub users:\n"
   api_request_forks "repos/$context/forks"
@@ -228,7 +235,6 @@ while [ "$1" != "" ]; do
                     GH_TOKEN="$1" ;;
     -u | --user )   shift
                     set_user_context "$1"
-                    echo "Context is $context"
                     user_details ;;
     -r | --repo )   shift
                     set_repo_context "$1"

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -1,29 +1,8 @@
 #!/usr/bin/env bash
-# TODO standardize format
+
 # set -x # for debugging
 
 . plumbing
-
-#### CORE FUNCTIONS
-
-api_request()
-{
-  local api_request_result=$( github_get "$1") # only make a single API request
-  shift # Shift 
-
-  api_request_filtered=() # initialize/empty filtered results array
-
-  # loop through all requested jq filter arguments
-  for arg in $* ; do
-    _response=$( echo $api_request_result | jq -r "$arg" )
-    if [[ -n $_response ]] ; then
-      api_request_filtered+=("$_response") # append to filtered result array
-    # else
-    #   echo "No response for $arg"
-    fi
-  done
-}
-
 
 #### COLORS & FORMATTING
 
@@ -45,7 +24,7 @@ _target=${_magenta}
 _em=${_blue}${_bold}
 
 
-##### META 
+#### INTERNAL METHODS & HELPERS
 
 dependency_test()
 {
@@ -58,16 +37,12 @@ usage()
 {
   echo -e "Usage: $0 [options] <argv>...\n"
   echo "Options:"
-  echo " -f | --forks <user/repository>   Display fork details"
-  echo " -r | --repo  <user/repository>   Display repo details"
-  echo " -u | --user  <username>          Display user details"
-  echo " -t | --token <token>             Set a GitHub token"
+  echo " -f | --forks <user/repository>   Display list of forks for a  repository"
+  echo " -r | --repo  <user/repository>   Display a summary of a repository"
+  echo " -u | --user  <username>          Display summary of a user"
   echo " -h | --help                      Help"
   echo ""
 }
-
-
-#### HELPERS - to reduce duplication
 
 set_user_context()
 {
@@ -100,24 +75,23 @@ print_header()
 
 
 #### FORMATTED REQUEST FUNCTIONS
-#    Uses format: `api_request 'API_ROUTE' 'FILTER1' 'FILTER2' ...`
 
 user_details()
 {
   print_header 
-  api_request "users/$context" '.name' '.location' '.email' '.bio' '.public_repos' '.public_gists' '.followers' '.following' '.created_at'
+  api_request_result=$(github_get "users/$context")
 
   local name_length=${#context}
 
-  local name=${api_request_filtered[0]}
-  local location=${api_request_filtered[1]}
-  local email=${api_request_filtered[2]}
-  local bio=${api_request_filtered[3]}
-  local public_repos=${api_request_filtered[4]}
-  local public_gists=${api_request_filtered[5]}
-  local followers=${api_request_filtered[6]}
-  local following=${api_request_filtered[7]}
-  local user_since=${api_request_filtered[8]}
+  local name=$( echo $api_request_result | jq -r '.name' )
+  local location=$( echo $api_request_result | jq -r '.location' )
+  local email=$( echo $api_request_result | jq -r '.email' )
+  local bio=$( echo $api_request_result | jq -r '.bio' )
+  local public_repos=$( echo $api_request_result | jq -r '.public_repos' )
+  local public_gists=$( echo $api_request_result | jq -r '.public_gists' )
+  local followers=$( echo $api_request_result | jq -r '.followers' )
+  local following=$( echo $api_request_result | jq -r '.following' )
+  local user_since=$( echo $api_request_result | jq -r '.created_at' )
 
   echo "     Name: $name"
   echo " Location: $location"
@@ -142,21 +116,22 @@ user_details()
 repo_details()
 {
   print_header 
-  api_request "repos/$context" '.name' '.owner.login' '.description' '.forks_count' '.stargazers_count' '.open_issues_count' '.created_at' '.updated_at' '.parent.name' '.parent.owner.login' '.clone_url' '.homepage'
+  api_request_result=$(github_get "repos/$context")
 
   local name_length=${#context}
-  local name=${api_request_filtered[0]}
-  local owner=${api_request_filtered[1]}
-  local description=${api_request_filtered[2]}
-  local forks_count=${api_request_filtered[3]}
-  local stargazers_count=${api_request_filtered[4]}
-  local open_issues_count=${api_request_filtered[5]}
-  local created_at=${api_request_filtered[6]}
-  local updated_at=${api_request_filtered[7]}
-  local parent_name=${api_request_filtered[8]}
-  local parent_owner=${api_request_filtered[9]}
-  local clone_url=${api_request_filtered[10]}
-  local homepage=${api_request_filtered[11]}
+
+  local name=$( echo $api_request_result | jq -r '.name' )
+  local owner=$( echo $api_request_result | jq -r '.owner.login' )
+  local description=$( echo $api_request_result | jq -r '.description' )
+  local forks_count=$( echo $api_request_result | jq -r '.forks_count' )
+  local stargazers_count=$( echo $api_request_result | jq -r '.stargazers_count' )
+  local open_issues_count=$( echo $api_request_result | jq -r '.open_issues_count' )
+  local created_at=$( echo $api_request_result | jq -r '.created_at' )
+  local updated_at=$( echo $api_request_result | jq -r '.updated_at' )
+  local parent_name=$( echo $api_request_result | jq -r '.parent.name' )
+  local parent_owner=$( echo $api_request_result | jq -r '.parent.owner.login' )
+  local clone_url=$( echo $api_request_result | jq -r '.clone_url' )
+  local homepage=$( echo $api_request_result | jq -r '.homepage' )
 
   echo -e " ${_bold}${_white}$name${_reset} by $owner\n"
   
@@ -187,11 +162,11 @@ repo_details()
 list_forks()
 {
   print_header 
-  api_request "repos/$context" '.name' '.owner.login' '.forks_count'
+  api_request_result=$(github_get "repos/$context")
 
-  local name=${api_request_filtered[0]}
-  local owner=${api_request_filtered[1]}
-  local forks_count=${api_request_filtered[2]}
+  local name=$( echo $api_request_result | jq -r '.name' )
+  local owner=$( echo $api_request_result | jq -r '.owner.login' )
+  local forks_count=$( echo $api_request_result | jq -r '.forks_count' )
 
   echo -e "${_bold}$name${_white}${_reset} by $owner\n"
   echo -e "\n${_target}$context${_reset} has been forked ${_em}$forks_count${_reset} times, including forks by these GitHub users:\n"
@@ -218,8 +193,6 @@ while [ "$1" != "" ]; do
   case $1 in
     -h | --help )   usage
                     exit ;;
-    -t | --token )  shift
-                    GH_TOKEN="$1" ;;
     -u | --user )   shift
                     set_user_context "$1"
                     user_details ;;

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -36,15 +36,6 @@ api_request()
   done
 }
 
-api_request_forks() # FIXME: refactor this into the main api_request function
-{
-  local api_request_result=$( gh_request "$1") # only make a single API request
-
-  api_request_filtered=() # initialize/empty filtered results array
-
-  response=$( echo $api_request_result | jq -r '.[] | .owner.login' )
-}
-
 
 #### COLORS & FORMATTING
 
@@ -209,9 +200,14 @@ list_forks()
   print_header 
   api_request "repos/$context" '.name' '.owner.login' '.forks_count'
 
-  echo -e "${_bold}${_white}${api_request_filtered[0]}${_reset} by ${api_request_filtered[1]}\n"
-  echo -e "\n${_target}$context${_reset} has been forked ${_em}${api_request_filtered[2]}${_reset} times, including forks by these GitHub users:\n"
-  api_request_forks "repos/$context/forks"
+  local name=${api_request_filtered[0]}
+  local owner=${api_request_filtered[1]}
+  local forks_count=${api_request_filtered[2]}
+
+  echo -e "${_bold}$name${_white}${_reset} by $owner\n"
+  echo -e "\n${_target}$context${_reset} has been forked ${_em}${_reset} times, including $forks_count forks by these GitHub users:\n"
+
+  api_request "repos/$context/forks" '.owner.login'
   echo -e "${_blue}$response${_reset}"
   echo ""
 }

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -195,6 +195,7 @@ repo_details()
   echo -e "\n Clone URL: $clone_url \n"
 }
 
+
 list_forks()
 {
   print_header 
@@ -205,9 +206,11 @@ list_forks()
   local forks_count=${api_request_filtered[2]}
 
   echo -e "${_bold}$name${_white}${_reset} by $owner\n"
-  echo -e "\n${_target}$context${_reset} has been forked ${_em}${_reset} times, including $forks_count forks by these GitHub users:\n"
+  echo -e "\n${_target}$context${_reset} has been forked ${_em}$forks_count${_reset} times, including forks by these GitHub users:\n"
 
-  api_request "repos/$context/forks" '.owner.login'
+  api_request_result=$(github_get "repos/$context/forks")
+
+  response=$( echo $api_request_result | jq -r '.[] | .owner.login' )
   echo -e "${_blue}$response${_reset}"
   echo ""
 }

--- a/api/bash/pretty-print
+++ b/api/bash/pretty-print
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-
+# TODO standardize format
 # set -x # for debugging
+
+. plumbing
 
 # TODO replace with plumbing
 gh_request()
@@ -67,8 +69,13 @@ set_repo_context()
   context=$(echo "$1" | sed -e 's/^https*:\/*//' -e 's/github\.com\/*//' -e 's/\.*git$//' -e 's#/$##')
 }
 
-print_header(){
+print_whitespace(){
+  for i in $(seq 1 $1); do
+      echo -n " "
+  done
+}
 
+print_header(){
   local name_length=${#context}
   local header_length=$(( name_length + 13 ))
   
@@ -77,7 +84,6 @@ print_header(){
     echo -n "="
   done
   echo -e "\n"
-  
 }
 
 #### CORE FUNCTIONS
@@ -119,12 +125,12 @@ user_details()
   print_header 
 
   local name_length=${#context}
-  local header_length=$(( name_length + 25 ))
   
   api_request "users/$context" '.name' '.location' '.email' '.bio' '.public_repos' '.public_gists' '.followers' '.following' '.created_at'
 
   echo "     Name: ${api_request_filtered[0]}"
   echo " Location: ${api_request_filtered[1]}"
+
   local email=${api_request_filtered[2]}
   local bio=${api_request_filtered[3]}
   local user_since=${api_request_filtered[8]}
@@ -151,39 +157,44 @@ user_details()
 repo_details()
 {
   print_header 
-
   api_request "repos/$context" '.name' '.owner.login' '.description' '.forks_count' '.stargazers_count' '.open_issues_count' '.created_at' '.updated_at' '.parent.name' '.parent.owner.login' '.clone_url' '.homepage'
 
+  local name_length=${#context}
+  local name=${api_request_filtered[0]}
+  local owner=${api_request_filtered[1]}
   local description=${api_request_filtered[2]}
+  local forks_count=${api_request_filtered[3]}
+  local stargazers_count=${api_request_filtered[4]}
+  local open_issues_count=${api_request_filtered[5]}
   local created_at=${api_request_filtered[6]}
   local updated_at=${api_request_filtered[7]}
   local parent_name=${api_request_filtered[8]}
   local parent_owner=${api_request_filtered[9]}
-  local homepage=${api_request_filtered[11]} # FIXME: dirty hack because GH returns an empty value instead of null
+  local clone_url=${api_request_filtered[10]}
+  local homepage=${api_request_filtered[11]}
 
-  echo -e " ${_bold}${_white}${api_request_filtered[0]}${_reset} by ${api_request_filtered[1]}\n"
+  echo -e " ${_bold}${_white}$name${_reset} by $owner\n"
+  
   if [ "$description" != "null" ]; then
     echo " $description" | fmt
-    echo ""
   fi
-  if [[ -n $homepage ]]; then
+
+  if [ "$homepage" != "null" ]; then
     echo " Homepage: $homepage"
   fi
-  echo -e "\n ${_target}$context${_reset} has been forked ${_em}${api_request_filtered[3]}${_reset} times and starred ${_em}${api_request_filtered[4]}${_reset} times.\n"
-  for i in $(seq 1 $name_length); do
-    echo -n " "
-  done
-  echo -e "  has ${_em}${api_request_filtered[5]}${_reset} open issues.\n"
-  for i in $(seq 1 $name_length); do
-    echo -n " "
-  done
+
+  echo -e "\n ${_target}$context${_reset} has been forked ${_em}$forks_count${_reset} times and starred ${_em}$stargazers_count${_reset} times.\n"
+  print_whitespace $name_length
+
+  echo -e "  has ${_em}$open_issues_count${_reset} open issues.\n"
+  print_whitespace $name_length
+
   echo -e "  was created on ${_em}${created_at:0:10}${_reset} and last updated on ${_em}${updated_at:0:10}${_reset}."
   if [ $parent_name != "null" ]; then
-    echo -e "\n\n ${_target}${api_request_filtered[0]}${_reset} was forked from ${_yellow}$parent_name${_yellow} by ${_yellow}$parent_owner${_reset}"
+    echo -e "\n\n ${_target}$name${_reset} was forked from ${_yellow}$parent_name${_yellow} by ${_yellow}$parent_owner${_reset}"
   fi
-  echo -e "\n Clone URL: ${api_request_filtered[10]}"
 
-  echo ""
+  echo -e "\n Clone URL: $clone_url \n"
 }
 
 list_forks()


### PR DESCRIPTION
I had some time today to work through the add-shell-scripts branch and make some changes I've been thinking about. I thought @nathos' script was really neat -- Perhaps it's slightly less approachable than the other scripts here, so I have made an effort to simplify it.

* Refactored `gh_request` from `pretty-print` into a new`plumbing` method: `github_get`
* Refactored `pretty-print` to use plumbing
* Added helper methods for setting user or repository context, outputting whitespace and pretty-printed headers
* Added `get-status` script
* Added some documentation about `set-status` and `get-status` scripts, as well as the required `GH_TOKEN`.
* Refreshed documentation to point users at the `./pretty-print -h` method -- Since this script already has a built in menu, I figured that may be explanation enough (I updated the `pretty-print` usage output to match what was previously in the README)

In order to simplify `pretty-print`, I updated each of the formatted request functions to invoke `jq` explicitly for each desired element. While this is perhaps, more repetitive than the former version, I believe the consumers of these platform-samples will find this easier to digest and modify than the positional results originally returned from the `api_request` method.
 
I really liked the `plumbing` approach - I'm thinking perhaps several different plumbing methods (at least one for get and one for post) would make sense here since we likely want to use different options for the `curl` command depending on the usage.

/cc @nathos @PatrickBM @jordanmccullough @mattcantstop 