### PR TITLE
add user audit

### DIFF
--- a/api/ruby/user-auditing/README.md
+++ b/api/ruby/user-auditing/README.md
@@ -1,4 +1,4 @@
-# User Audit
+# Suspended User Audit
 
 Lists total number of active, suspended, and recently suspended users. Gives the option to unsuspend all recently suspended users. This is mostly useful when a configuration change may have caused a large number of users to become suspended.
 
@@ -32,5 +32,5 @@ export OCTOKIT_ACCESS_TOKEN=00000000000000000000000
 ### Execute
 
 ```shell
-ruby user_audit.rb
+ruby suspended_user_audit.rb
 ```

--- a/api/ruby/user-auditing/README.md
+++ b/api/ruby/user-auditing/README.md
@@ -1,0 +1,36 @@
+# User Audit
+
+Lists total number of active, suspended, and recently suspended users. Gives the option to unsuspend all recently suspended users. This is mostly useful when a configuration change may have caused a large number of users to become suspended.
+
+## Installation
+
+
+### Clone this repository
+
+```shell
+git clone git@github.com:github/platform-samples.git
+cd api/ruby/user-auditing
+```
+
+
+### Install dependencies
+
+```shell
+gem install octokit
+```
+
+
+## Usage
+
+### Configure Octokit
+
+```shell
+export OCTOKIT_API_ENDPOINT="https://github.example.com/api/v3" # Default: "https://api.github.com"
+export OCTOKIT_ACCESS_TOKEN=00000000000000000000000
+```
+
+### Execute
+
+```shell
+ruby user_audit.rb
+```

--- a/api/ruby/user-auditing/suspended_user_audit.rb
+++ b/api/ruby/user-auditing/suspended_user_audit.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# User Audit - Generated with Octokitchen https://github.com/kylemacey/octokitchen
+# Suspended User Audit - Generated with Octokitchen https://github.com/kylemacey/octokitchen
 
 # Dependencies
 require "octokit"

--- a/api/ruby/user-auditing/user_audit.rb
+++ b/api/ruby/user-auditing/user_audit.rb
@@ -12,7 +12,7 @@ end
 client = Octokit::Client.new
 users = client.all_users
 n = 1
-puts "Importing users..."
+puts "Aggregating users..."
 full_users = users.map { |u|
   print "\r#{n}/#{users.count}"
   n += 1
@@ -29,9 +29,12 @@ active = full_users.select do |u|
   u.suspended_at.nil? rescue false;
 end
 
-two_days = 172800
+seconds_in_two_days = 60 * # seconds in an minute
+                      60 * # minutes in an hour
+                      48   # hours in 2 days
+
 recent = suspended.select do |u|
-  u[:suspended_at] > (Time.now - two_days)
+  u[:suspended_at] > (Time.now - seconds_in_two_days)
 end
 
 puts ""

--- a/api/ruby/user-auditing/user_audit.rb
+++ b/api/ruby/user-auditing/user_audit.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+# User Audit - Generated with Octokitchen https://github.com/kylemacey/octokitchen
+
+# Dependencies
+require "octokit"
+
+Octokit.configure do |kit|
+  kit.auto_paginate = true
+end
+
+client = Octokit::Client.new
+users = client.all_users
+n = 1
+puts "Importing users..."
+full_users = users.map { |u|
+  print "\r#{n}/#{users.count}"
+  n += 1
+  client.user(u.login) rescue nil;
+}
+
+suspended = full_users.select do |u|
+  next unless u
+  !u.suspended_at.nil? rescue false;
+end
+
+active = full_users.select do |u|
+  next unless u
+  u.suspended_at.nil? rescue false;
+end
+
+two_days = 172800
+recent = suspended.select do |u|
+  u[:suspended_at] > (Time.now - two_days)
+end
+
+puts ""
+puts ""
+puts "Suspended: #{suspended.count}"
+puts "Recently Suspended: #{recent.count}"
+puts "Active: #{active.count}"
+
+puts ""
+
+print "Unsuspend recently suspended users? (y/N) "
+
+if gets.rstrip == "y"
+  ent = Octokit::EnterpriseAdminClient.new
+
+  recent.each do |u|
+    ent.unsuspend u[:login]
+  end
+end


### PR DESCRIPTION
Lists total number of active, suspended, and recently suspended users. Gives the option to unsuspend all recently suspended users. This is mostly useful when a configuration change may have caused a large number of users to become suspended.