### PR TITLE
Use HTTPS (not HTTP) for api.github.com

### DIFF
--- a/api/ruby/2fa_checker.rb
+++ b/api/ruby/2fa_checker.rb
@@ -6,7 +6,7 @@
 # These environment variables must be set:
 # - GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges
 # - GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL
-#                        (use http://api.github.com for GitHub.com auditing)
+#                        (use https://api.github.com for GitHub.com auditing)
 #
 # Requires the Octokit Rubygem: https://github.com/octokit/octokit.rb
 
@@ -19,7 +19,7 @@ rescue KeyError
   $stderr.puts "To run this script, please set the following environment variables:"
   $stderr.puts "- GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges"
   $stderr.puts "- GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL"
-  $stderr.puts "                       (use http://api.github.com for GitHub.com auditing)"
+  $stderr.puts "                       (use https://api.github.com for GitHub.com auditing)"
   exit 1
 end
 

--- a/api/ruby/instance-auditing/instance_auditor.rb
+++ b/api/ruby/instance-auditing/instance_auditor.rb
@@ -7,7 +7,7 @@
 # These environment variables must be set:
 # - GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges
 # - GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL
-#                        (use http://api.github.com for GitHub.com auditing)
+#                        (use https://api.github.com for GitHub.com auditing)
 #
 # Requires the Octokit Rubygem: https://github.com/octokit/octokit.rb
 # Requires the axlsx Rubygem:   https://github.com/randym/axlsx
@@ -22,7 +22,7 @@ rescue KeyError
   $stderr.puts "To run this script, please set the following environment variables:"
   $stderr.puts "- GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges"
   $stderr.puts "- GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL"
-  $stderr.puts "                       (use http://api.github.com for GitHub.com auditing)"
+  $stderr.puts "                       (use https://api.github.com for GitHub.com auditing)"
   exit 1
 end
 

--- a/api/ruby/team_audit.rb
+++ b/api/ruby/team_audit.rb
@@ -6,7 +6,7 @@
 # These environment variables must be set:
 # - GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges
 # - GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL
-#                        (use http://api.github.com for GitHub.com auditing)
+#                        (use https://api.github.com for GitHub.com auditing)
 #
 # Requires the Octokit Rubygem: https://github.com/octokit/octokit.rb
 
@@ -19,7 +19,7 @@ rescue KeyError
   $stderr.puts "To run this script, please set the following environment variables:"
   $stderr.puts "- GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges"
   $stderr.puts "- GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL"
-  $stderr.puts "                       (use http://api.github.com for GitHub.com auditing)"
+  $stderr.puts "                       (use https://api.github.com for GitHub.com auditing)"
   exit 1
 end
 


### PR DESCRIPTION
A handful of scripts include references to `http://api.github.com`. In order to use api.github.com, requests must be made via HTTPS, not HTTP.

This pull request replaces all instances of `http://api.github.com` with `https://api.github.com` so that [developers reading these scripts don't run into issues](http://stackoverflow.com/questions/33082535/no-connection-could-be-made-to-github#comment53982393_33082535) trying to use HTTP instead of HTTPS. 

```
$ curl -v http://api.github.com
* Rebuilt URL to: http://api.github.com/
*   Trying 192.30.252.124...
* connect to 192.30.252.124 port 80 failed: Connection refused
* Failed to connect to api.github.com port 80: Connection refused
* Closing connection 0
```

/cc @kylemacey @gjtorikian for review