### PR TITLE
Easier configuration for Basics of Authentication "Good" example

### DIFF
--- a/api/ruby/basics-of-authentication/README.md
+++ b/api/ruby/basics-of-authentication/README.md
@@ -13,6 +13,9 @@ To run these projects, make sure you have [Bundler][bundler] installed; then typ
 For the "less optimal" server, type `ruby server.rb` on the command line.
 
 For the correct server, enter `ruby advanced_server.rb` on the command line.
+See `advanced_server.rb` for environment variables you can set, including
+non-production environments. If any config variables are missing, you'll be
+prompted to supply them before the server starts.
 
 Both commands will run the server at `localhost:4567`.
 

--- a/api/ruby/basics-of-authentication/README.md
+++ b/api/ruby/basics-of-authentication/README.md
@@ -14,8 +14,8 @@ For the "less optimal" server, type `ruby server.rb` on the command line.
 
 For the correct server, enter `ruby advanced_server.rb` on the command line.
 See `advanced_server.rb` for environment variables you can set, including
-non-production environments. If any config variables are missing, you'll be
-prompted to supply them before the server starts.
+alternate GitHub URLs. If any config variables are missing, you'll be prompted
+to supply them before the server starts.
 
 Both commands will run the server at `localhost:4567`.
 

--- a/api/ruby/basics-of-authentication/advanced_server.rb
+++ b/api/ruby/basics-of-authentication/advanced_server.rb
@@ -15,7 +15,7 @@ include CLIHelper
 
 CLIENT_ID       = ENV["GITHUB_CLIENT_ID"] || get_required_from_user("Client ID")
 CLIENT_SECRET   = ENV["GITHUB_CLIENT_SECRET"] || get_required_from_user("Client Secret")
-BASE_GITHUB_URL = ENV["GITHUB_URL"] || get_required_from_user("Base GitHub URL", default: "https://github.com")
+BASE_GITHUB_URL = ENV["GITHUB_URL"] || get_required_from_user("Base GitHub URL", :default => "https://github.com")
 BASE_API_URL    = case URI.parse(BASE_GITHUB_URL).host
                   when "github.com"
                     "https://api.github.com"

--- a/api/ruby/basics-of-authentication/advanced_server.rb
+++ b/api/ruby/basics-of-authentication/advanced_server.rb
@@ -1,16 +1,34 @@
-require 'sinatra'
-require 'rest_client'
-require 'json'
+require "sinatra"
+require "rest_client"
+require "uri"
+require "json"
+require_relative "cli_helper"
+
+include CLIHelper
 
 # !!! DO NOT EVER USE HARD-CODED VALUES IN A REAL APP !!!
 # Instead, set and test environment variables, like below
-# if ENV['GITHUB_CLIENT_ID'] && ENV['GITHUB_CLIENT_SECRET']
-#  CLIENT_ID        = ENV['GITHUB_CLIENT_ID']
-#  CLIENT_SECRET    = ENV['GITHUB_CLIENT_SECRET']
+# if ENV["GITHUB_CLIENT_ID"] && ENV["GITHUB_CLIENT_SECRET"]
+#  CLIENT_ID        = ENV["GITHUB_CLIENT_ID"]
+#  CLIENT_SECRET    = ENV["GITHUB_CLIENT_SECRET"]
 # end
 
-CLIENT_ID = ENV['GH_BASIC_CLIENT_ID']
-CLIENT_SECRET = ENV['GH_BASIC_SECRET_ID']
+CLIENT_ID       = ENV["GITHUB_CLIENT_ID"] || get_required_from_user("Client ID")
+CLIENT_SECRET   = ENV["GITHUB_CLIENT_SECRET"] || get_required_from_user("Client Secret")
+BASE_GITHUB_URL = ENV["GITHUB_URL"] || get_required_from_user("Base GitHub URL", default: "https://github.com")
+BASE_API_URL    = case URI.parse(BASE_GITHUB_URL).host
+                  when "github.com"
+                    "https://api.github.com"
+                  when "github.dev"
+                    "http://api.github.dev"
+                  else
+                    "#{BASE_GITHUB_URL}/api/v3"
+                  end
+
+puts "<--------------------------------------------------------------------->"
+puts "GitHub lives here: #{BASE_GITHUB_URL}"
+puts "The GitHub API lives here: #{BASE_API_URL}"
+puts "<--------------------------------------------------------------------->"
 
 use Rack::Session::Pool, :cookie_only => false
 
@@ -19,10 +37,10 @@ def authenticated?
 end
 
 def authenticate!
-  erb :index, :locals => {:client_id => CLIENT_ID}
+  erb :index, :locals => {:client_id => CLIENT_ID, :base_url => BASE_GITHUB_URL}
 end
 
-get '/' do
+get "/" do
   if !authenticated?
     authenticate!
   else
@@ -30,7 +48,7 @@ get '/' do
     scopes = []
 
     begin
-      auth_result = RestClient.get('https://api.github.com/user',
+      auth_result = RestClient.get("#{BASE_API_URL}/user",
                                    {:params => {:access_token => access_token},
                                     :accept => :json})
     rescue => e
@@ -44,14 +62,14 @@ get '/' do
 
     # the request succeeded, so we check the list of current scopes
     if auth_result.headers.include? :x_oauth_scopes
-      scopes = auth_result.headers[:x_oauth_scopes].split(', ')
+      scopes = auth_result.headers[:x_oauth_scopes].split(", ")
     end
 
     auth_result = JSON.parse(auth_result)
 
-    if scopes.include? 'user:email'
-      auth_result['private_emails'] =
-        JSON.parse(RestClient.get('https://api.github.com/user/emails',
+    if scopes.include? "user:email"
+      auth_result["private_emails"] =
+        JSON.parse(RestClient.get("#{BASE_API_URL}/user/emails",
                        {:params => {:access_token => access_token},
                         :accept => :json}))
     end
@@ -60,16 +78,18 @@ get '/' do
   end
 end
 
-get '/callback' do
-  session_code = request.env['rack.request.query_hash']['code']
+get "/callback" do
+  session_code = request.env["rack.request.query_hash"]["code"]
 
-  result = RestClient.post('https://github.com/login/oauth/access_token',
+  binding.pry
+
+  result = RestClient.post("#{BASE_GITHUB_URL}/login/oauth/access_token",
                           {:client_id => CLIENT_ID,
                            :client_secret => CLIENT_SECRET,
                            :code => session_code},
                            :accept => :json)
 
-  session[:access_token] = JSON.parse(result)['access_token']
+  session[:access_token] = JSON.parse(result)["access_token"]
 
-  redirect '/'
+  redirect "/"
 end

--- a/api/ruby/basics-of-authentication/advanced_server.rb
+++ b/api/ruby/basics-of-authentication/advanced_server.rb
@@ -81,8 +81,6 @@ end
 get "/callback" do
   session_code = request.env["rack.request.query_hash"]["code"]
 
-  binding.pry
-
   result = RestClient.post("#{BASE_GITHUB_URL}/login/oauth/access_token",
                           {:client_id => CLIENT_ID,
                            :client_secret => CLIENT_SECRET,

--- a/api/ruby/basics-of-authentication/cli_helper.rb
+++ b/api/ruby/basics-of-authentication/cli_helper.rb
@@ -1,0 +1,15 @@
+module CLIHelper
+  def get_from_user(something, options)
+    default_value = options[:default]
+    STDOUT.write("Please enter a value for #{something}")
+    STDOUT.write(" or, just hit Enter to stick with the default (#{default_value})") if default_value
+    STDOUT.write(": ")
+    user_entered_value = STDIN.gets.chomp
+    user_entered_value.length == 0 ? default_value : user_entered_value
+  end
+
+  def get_required_from_user(something, options={})
+    get_from_user(something, options) or abort("Sorry, #{something} is required.")
+  end
+end
+

--- a/api/ruby/basics-of-authentication/views/index.erb
+++ b/api/ruby/basics-of-authentication/views/index.erb
@@ -6,7 +6,7 @@
   </head>
   <body>
     <p>Well, hello there!</p>
-    <p>We're going to now talk to the GitHub API. Ready? <a href="<%= base_url %>/login/oauth/authorize?scope=user:email&client_id=<%= client_id %>">Click here</a> to begin!</a></p>
+    <p>We're going to now talk to the GitHub API. Ready? <a href="<%= base_url %>/login/oauth/authorize?scope=user:email&client_id=<%= client_id %>">Click here</a> to begin!</p>
     <p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
   </body>
 </html>

--- a/api/ruby/basics-of-authentication/views/index.erb
+++ b/api/ruby/basics-of-authentication/views/index.erb
@@ -6,7 +6,7 @@
   </head>
   <body>
     <p>Well, hello there!</p>
-    <p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id=<%= client_id %>">Click here</a> to begin!</a></p>
+    <p>We're going to now talk to the GitHub API. Ready? <a href="<%= base_url %>/login/oauth/authorize?scope=user:email&client_id=<%= client_id %>">Click here</a> to begin!</a></p>
     <p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
   </body>
 </html>


### PR DESCRIPTION
I ran into a few issues using the Basics of Authentication sample app (`advanced_server.rb`):
1. The GitHub URL wasn't configurable. This is generally okay, but I needed to point the sample app at a different :octocat: URL for testing.
2. I didn't like having to remember environment variables. :grin: 
3. Missing or mis-typed configuration options didn't fail loudly, and I usually found out about them by clicking around in the browser getting confusing error messages.

This PR introduces `STDIN` fallbacks for missing configuration. It also elevates the GitHub URL to a configuration option (defaulting to `https://github.com` instead of hardcoding in various places. The API base URL is set programmatically based on the :octocat: URL (please check my logic here).

---
### Happy-path usage:

```
ruby advanced_server.rb
Please enter a value for Client ID: 123
Please enter a value for Client Secret: 456
Please enter a value for Base GitHub URL or, just hit Enter to stick with the default (https://github.com):
<--------------------------------------------------------------------->
GitHub lives here: https://github.com
The GitHub API lives here: https://api.github.com
<--------------------------------------------------------------------->
[2015-12-07 16:16:42] INFO  WEBrick 1.3.1
[2015-12-07 16:16:42] INFO  ruby 2.1.5 (2014-11-13) [x86_64-darwin14.0]
== Sinatra/1.3.5 has taken the stage on 4567 for development with backup from WEBrick
[2015-12-07 16:16:42] INFO  WEBrick::HTTPServer#start: pid=57700 port=4567
```
### Non-interactive usage:

``` bash
GITHUB_URL=https://github.com \
  GITHUB_CLIENT_ID=123 \
  GITHUB_CLIENT_SECRET=456 \
  ruby advanced_server.rb
<--------------------------------------------------------------------->
GitHub lives here: https://github.com
The GitHub API lives here: https://api.github.com
<--------------------------------------------------------------------->
[2015-12-08 09:43:22] INFO  WEBrick 1.3.1
[2015-12-08 09:43:22] INFO  ruby 2.1.5 (2014-11-13) [x86_64-darwin14.0]
== Sinatra/1.3.5 has taken the stage on 4567 for development with backup from WEBrick
[2015-12-08 09:43:22] INFO  WEBrick::HTTPServer#start: pid=63796 port=4567
```
### Specifying an alternate GitHub URL:

```
ruby advanced_server.rb
Please enter a value for Client ID: 123
Please enter a value for Client Secret: 456
Please enter a value for Base GitHub URL or, just hit Enter to stick with the default (https://github.com): https://ghe.acme.co
<--------------------------------------------------------------------->
GitHub lives here: https://ghe.acme.co
The GitHub API lives here: https://ghe.acme.co/api/v3
<--------------------------------------------------------------------->
```
### Omitting a required option:

```
ruby advanced_server.rb
Please enter a value for Client ID:
Sorry, Client ID is required.
```
