### PR TITLE
Update all Gemfiles to use json 1.8+

### DIFF
--- a/api/ruby/building-a-ci-server/Gemfile
+++ b/api/ruby/building-a-ci-server/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "json",        "1.7.7"
+gem "json",        "~> 1.8"
 gem 'sinatra',     '~> 1.3.5'
 gem "shotgun"
 gem "octokit",     '~> 3.0'

--- a/api/ruby/building-a-ci-server/Gemfile.lock
+++ b/api/ruby/building-a-ci-server/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.3.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    json (1.7.7)
+    json (1.8.3)
     multipart-post (2.0.0)
     octokit (3.0.0)
       sawyer (~> 0.5.3)
@@ -26,7 +26,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (= 1.7.7)
+  json (~> 1.8)
   octokit (~> 3.0)
   shotgun
   sinatra (~> 1.3.5)
+
+BUNDLED WITH
+   1.11.2

--- a/api/ruby/delivering-deployments/Gemfile
+++ b/api/ruby/delivering-deployments/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "json",        "1.7.7"
+gem "json",        "~> 1.8"
 gem 'sinatra',     '~> 1.3.5'
 gem "shotgun"
 gem "octokit",     '~> 3.0'

--- a/api/ruby/delivering-deployments/Gemfile.lock
+++ b/api/ruby/delivering-deployments/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.3.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    json (1.7.7)
+    json (1.8.3)
     multipart-post (2.0.0)
     octokit (3.0.0)
       sawyer (~> 0.5.3)
@@ -26,7 +26,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (= 1.7.7)
+  json (~> 1.8)
   octokit (~> 3.0)
   shotgun
   sinatra (~> 1.3.5)
+
+BUNDLED WITH
+   1.11.2

--- a/api/ruby/rendering-data-as-graphs/Gemfile
+++ b/api/ruby/rendering-data-as-graphs/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "json",        "1.7.7"
+gem "json",        "~> 1.8"
 gem 'sinatra',     '~> 1.3.5'
 gem 'sinatra_auth_github', '~> 0.13.3'
 gem 'octokit', '~> 1.23.0'

--- a/api/ruby/rendering-data-as-graphs/Gemfile.lock
+++ b/api/ruby/rendering-data-as-graphs/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
     hashie (1.2.0)
-    json (1.7.7)
+    json (1.8.3)
     multi_json (1.6.1)
     multipart-post (1.2.0)
     netrc (0.7.7)
@@ -39,7 +39,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (= 1.7.7)
+  json (~> 1.8)
   octokit (~> 1.23.0)
   sinatra (~> 1.3.5)
   sinatra_auth_github (~> 0.13.3)
+
+BUNDLED WITH
+   1.11.2

--- a/hooks/ruby/configuring-your-server/Gemfile
+++ b/hooks/ruby/configuring-your-server/Gemfile
@@ -1,4 +1,4 @@
 source "http://rubygems.org"
 
-gem "json",        "1.7.7"
+gem "json",        "~> 1.8"
 gem 'sinatra',     '~> 1.3.5'

--- a/hooks/ruby/configuring-your-server/Gemfile.lock
+++ b/hooks/ruby/configuring-your-server/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.7.7)
+    json (1.8.3)
     rack (1.5.2)
     rack-protection (1.5.2)
       rack
@@ -15,5 +15,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (= 1.7.7)
+  json (~> 1.8)
   sinatra (~> 1.3.5)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Initially only the basics-of-authentication Gemfile had an entry: `gem "json",        "~> 1.8"`.

This merge corrects all Gemfiles in the repo that use json to require `"~> 1.8"`. Also all the Gemfile.lock files were regenerated.