### PR TITLE
Rack requires `bundle exec` command

### DIFF
--- a/api/ruby/rendering-data-as-graphs/README.md
+++ b/api/ruby/rendering-data-as-graphs/README.md
@@ -7,7 +7,7 @@ guide on developer.github.com.
 To run these projects, make sure you have [Bundler][bundler] installed; then type
 `bundle install` on the command line.
 
-Then, enter `rackup -p 4567` on the command line.
+Then, enter `bundle exec rackup -p 4567` on the command line.
 
 [rendering data]: http://developer.github.com/guides/rendering-data-as-graphs/
 [bundler]: http://gembundler.com/


### PR DESCRIPTION
@gjtorikian @nathos @kylemacey / @github

----

> **[*Rack*](https://github.com/rack/rack) requires `bundle exec ...` command!**

Because if we run `rackup -p 4567`, we get this error output:

```powershell
C:\Users\Suriyaa\Downloads\PROJECTS\RUBY\rendering-data-as-graphs>rackup -p 4567
Gem::LoadError: You have already activated rack 1.6.4, but your Gemfile requires rack 1.5.2. Prepending `bundle exec` to your command may solve this.
                     block in setup at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/runtime.rb:35
                               each at org/jruby/RubyArray.java:1560
                               each at C:/Ruby/jruby-9.0.5.0/lib/ruby/stdlib/forwardable.rb:183
                                map at org/jruby/RubyEnumerable.java:800
                              setup at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/runtime.rb:20
                              setup at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler.rb:95
                              <top> at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/setup.rb:9
                            require at org/jruby/RubyKernel.java:937
                             (root) at C:/Ruby/jruby-9.0.5.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
                   block in require at C:/Ruby/jruby-9.0.5.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:128
                      instance_eval at org/jruby/RubyBasicObject.java:1633
                    new_from_string at C:/Users/Suriyaa/Downloads/PROJECTS/RUBY/rendering-data-as-graphs/config.ru:3
                             <eval> at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/builder.rb:55
                               eval at org/jruby/RubyKernel.java:976
                    new_from_string at C:/Users/Suriyaa/Downloads/PROJECTS/RUBY/rendering-data-as-graphs/config.ru:1
                    new_from_string at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/builder.rb:49
                         parse_file at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/builder.rb:40
  build_app_and_options_from_config at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/server.rb:299
                                app at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/server.rb:208
                        wrapped_app at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/server.rb:336
                              start at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/server.rb:272
                              <top> at C:/Ruby/jruby-9.0.5.0/lib/ruby/gems/shared/gems/rack-1.6.4/lib/rack/server.rb:147
                               load at org/jruby/RubyKernel.java:955
                              <top> at c:\Ruby\jruby-9.0.5.0\bin\rackup:23

C:\Users\Suriyaa\Downloads\PROJECTS\RUBY\rendering-data-as-graphs>
```

----

The correct command is `bundle exec rackup -p 4567`:

```powershell
C:\Users\Suriyaa\Downloads\PROJECTS\RUBY\rendering-data-as-graphs>bundle exec rackup -p 4567
[2016-06-24 14:32:13] INFO  WEBrick 1.3.1
[2016-06-24 14:32:13] INFO  ruby 2.2.3 (2016-01-26) [java]
[2016-06-24 14:32:13] INFO  WEBrick::HTTPServer#start: pid=3300 port=4567
...
```

*Yours,*
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat: