### PR TITLE
Pre-receive hook script to block pushes with a specific branch name

### DIFF
--- a/pre-receive-hooks/block_branch_names.sh
+++ b/pre-receive-hooks/block_branch_names.sh
@@ -13,7 +13,7 @@ zero_commit="0000000000000000000000000000000000000000"
 while read oldrev newrev refname; do
   # Prevent creation of new branches that don't match `^refs/heads/[a-z]+$`
   if [[ $oldrev == $zero_commit && ! $refname =~ ^refs/heads/[a-z]+$ ]]; then
-    echo "Blocking creation of new branch $refname because it must only contain lower-case alphabet characters."
+    echo "Blocking creation of new branch $refname because it must only contain lower-case alphabetical characters."
     exit 1
   fi
 done

--- a/pre-receive-hooks/block_branch_names.sh
+++ b/pre-receive-hooks/block_branch_names.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# Pre-receive hook that will block any new commits that their names contain
+# other than lower-case alphabet characters (a-z).
+#
+# More details on pre-receive hooks and how to apply them can be found on
+# https://help.github.com/enterprise/admin/guides/developer-workflow/managing-pre-receive-hooks-on-the-github-enterprise-appliance/
+#
+
+zero_commit="0000000000000000000000000000000000000000"
+
+while read oldrev newrev refname; do
+  # Prevent creation of new branches that don't match `^refs/heads/[a-z]+$`
+  if [[ $oldrev == $zero_commit && ! $refname =~ ^refs/heads/[a-z]+$ ]]; then
+    echo "Blocking creation of new branch $refname because it must only contain lower-case alphabet characters."
+    exit 1
+  fi
+done
+exit 0


### PR DESCRIPTION
To ensure branch names follow a specific rule.

This sample script returns `1` when the branch name contains other than lower case alphabetical characters.