### PR TITLE
add script to restrict changes on default branch to PRs

### DIFF
--- a/pre-receive-hooks/restrict-master-to-gui-merges.sh
+++ b/pre-receive-hooks/restrict-master-to-gui-merges.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This hook restricts changes on the default branch to those made with the GUI Pull Request Merge button, or the Pull Request Merge API.
+#
+DEFAULT_BRANCH=$(git symbolic-ref HEAD)
+while read -r oldrev newrev refname; do
+  if [[ "${refname}" != "${DEFAULT_BRANCH:=refs/heads/master}" ]]; then
+    exit 0
+  else
+    if [[ "${GITHUB_VIA}" != 'pull request merge button' && \
+          "${GITHUB_VIA}" != 'pull request merge api' ]]; then
+      echo "Changes to the default branch must be made by Pull Request. Direct pushes, edits, or merges are not allowed."
+      exit 1
+    else
+      exit 0
+    fi
+  fi
+done


### PR DESCRIPTION
This sample pre-receive hook script will block any changes to the default branch that are not made via Pull Request. 