### PR TITLE
added nil check for email

### DIFF
--- a/api/ruby/basics-of-authentication/views/basic.erb
+++ b/api/ruby/basics-of-authentication/views/basic.erb
@@ -7,7 +7,7 @@
   <body>
     <p>Hello, <%= login %>!</p>
     <p>
-      <% if !email.empty? %> It looks like your public email address is <%= email %>.
+      <% if !email.nil? && !email.empty? %> It looks like your public email address is <%= email %>.
       <% else %> It looks like you don't have a public email. That's cool.
       <% end %>
     </p>


### PR DESCRIPTION
After login to an account without a public e-mail address I get this error:

```
NoMethodError at /callback
undefined method `empty?' for nil:NilClass
    file: basic.erb location: block in singleton class line: 3 
```

Adding a check for `!email.nil?` resolves it.
