### PR TITLE
Add Ruby webhook server to dismiss reviews

### DIFF
--- a/hooks/ruby/dismiss-review-server/Gemfile
+++ b/hooks/ruby/dismiss-review-server/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+gem "json",        "~> 1.8"
+gem 'sinatra',     '~> 1.3.5'

--- a/hooks/ruby/dismiss-review-server/Gemfile
+++ b/hooks/ruby/dismiss-review-server/Gemfile
@@ -2,3 +2,4 @@ source "http://rubygems.org"
 
 gem "json",        "~> 1.8"
 gem 'sinatra',     '~> 1.3.5'
+gem 'rest-client'

--- a/hooks/ruby/dismiss-review-server/Gemfile.lock
+++ b/hooks/ruby/dismiss-review-server/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    json (1.8.3)
+    rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
+    sinatra (1.3.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
+      tilt (~> 1.3, >= 1.3.3)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json (~> 1.8)
+  sinatra (~> 1.3.5)
+
+BUNDLED WITH
+   1.11.2

--- a/hooks/ruby/dismiss-review-server/Gemfile.lock
+++ b/hooks/ruby/dismiss-review-server/Gemfile.lock
@@ -1,21 +1,37 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     json (1.8.6)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    netrc (0.11.0)
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
+    rest-client (2.0.1)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     sinatra (1.3.6)
       rack (~> 1.4)
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     tilt (1.4.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   json (~> 1.8)
+  rest-client
   sinatra (~> 1.3.5)
 
 BUNDLED WITH

--- a/hooks/ruby/dismiss-review-server/Gemfile.lock
+++ b/hooks/ruby/dismiss-review-server/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.8.3)
-    rack (1.5.2)
-    rack-protection (1.5.2)
+    json (1.8.6)
+    rack (1.6.5)
+    rack-protection (1.5.3)
       rack
     sinatra (1.3.6)
       rack (~> 1.4)
@@ -19,4 +19,4 @@ DEPENDENCIES
   sinatra (~> 1.3.5)
 
 BUNDLED WITH
-   1.11.2
+   1.14.4

--- a/hooks/ruby/dismiss-review-server/README.md
+++ b/hooks/ruby/dismiss-review-server/README.md
@@ -1,0 +1,9 @@
+# Dismiss Review Server
+
+A ruby server that listens for GitHub webhook `push` events, based on [the documentation](https://developer.github.com/webhooks/configuring/#writing-the-server), that will cancel any `APPROVED` [Pull Request Reviews](https://help.github.com/articles/about-pull-request-reviews/).
+
+## Configuration
+
+Follow the [instructions](https://developer.github.com/webhooks/) of setting up a Webhook on GitHub to this server. Set the following environment variables:
+- GITHUB_API_TOKEN - (Required) [OAuth token](https://developer.github.com/v3/#authentication) with write access to the repository.
+- SECRET_TOKEN - (Optional) [Shared secret token](https://developer.github.com/webhooks/securing/#validating-payloads-from-github) between the GitHub Webhook and this application. Leave this unset if not using a secret token.

--- a/hooks/ruby/dismiss-review-server/README.md
+++ b/hooks/ruby/dismiss-review-server/README.md
@@ -1,6 +1,6 @@
 # Dismiss Review Server
 
-A ruby server that listens for GitHub webhook `push` events, based on [the documentation](https://developer.github.com/webhooks/configuring/#writing-the-server), that will cancel any `APPROVED` [Pull Request Reviews](https://help.github.com/articles/about-pull-request-reviews/).
+A ruby server that listens for GitHub webhook `push` events, based on [the documentation](https://developer.github.com/webhooks/configuring/#writing-the-server), that will dismiss any `APPROVED` [Pull Request Reviews](https://help.github.com/articles/about-pull-request-reviews/).
 
 ## Configuration
 

--- a/hooks/ruby/dismiss-review-server/server.rb
+++ b/hooks/ruby/dismiss-review-server/server.rb
@@ -1,0 +1,117 @@
+require 'sinatra'
+require 'json'
+require 'uri'
+require 'net/http'
+
+$github_api_token = ENV['GITHUB_API_TOKEN']
+
+post '/payload' do
+
+  github_event = request.env['HTTP_X_GITHUB_EVENT']
+
+  if github_event == "push"
+    parsed = JSON.parse(request.body.read)
+
+    # Get branch information
+    branch_head = parsed['ref']
+    branch_name = branch_head.chomp("refs/heads")
+    repo_owner = parsed["repository"]["owner"]["name"]
+
+    # Create URL to look up Pull Requests for this branch
+    pulls_url = parsed['repository']['pulls_url']
+    puts pulls_url_filtered = pulls_url.split('{').first + "?head=#{repo_owner}:#{branch_name}"
+    url =  URI(pulls_url_filtered)
+    pulls = getPulls(url)
+
+    # parse pull requests
+    if pulls.empty?
+      puts "empty"
+    else
+      pulls.each do |pull_request|
+
+        # Get all Reviews for a Pull Request via API
+        review_url_orig = pull_request["url"] + "/reviews"
+        puts review_url = URI(review_url_orig)
+        reviews = getReviewList(review_url)
+
+        reviews.each do |review|
+          puts review["state"]
+          review_id = review["id"]
+
+          # Dismiss all Reviews that 'Approved' via API
+          if review["state"] == "APPROVED"
+            puts "INFO: found an approved"
+            puts dismiss_url = URI(review_url_orig + "/#{review_id}/dismissals")
+            put(dismiss_url)
+          end
+        end.empty? and begin
+          puts "no reviews"
+        end
+      end
+    end
+  elsif github_event == "ping"
+    puts github_event
+  else
+    puts github_event
+  end
+  "message received"
+end
+
+def put(url)
+  http = Net::HTTP.new(url.host, url.port)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  request = Net::HTTP::Put.new(url)
+  request["authorization"] = "token #{$github_api_token}"
+  request["accept"] = 'application/vnd.github.black-cat-preview+json'
+  request["content"] = '0'
+  request["content-type"] = 'application/json'
+  request["cache-control"] = 'no-cache'
+  request.body = "{\n\t\"message\":\"Auto-dismissing\"\n}"
+
+  response = http.request(request)
+  if response.message != "OK"
+    []
+  else
+    JSON.parse(response.read_body)
+  end
+end
+
+# https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
+def getReviewList(url)
+  http = Net::HTTP.new(url.host, url.port)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  request = Net::HTTP::Get.new(url)
+  request["authorization"] = "token #{$github_api_token}"
+  request["accept"] = 'application/vnd.github.black-cat-preview+json'
+  request["cache-control"] = 'no-cache'
+
+  response = http.request(request)
+  if response.message != "OK"
+    []
+  else
+    JSON.parse(response.read_body)
+  end
+end
+
+def getPulls(url)
+  http = Net::HTTP.new(url.host, url.port)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  request = Net::HTTP::Get.new(url)
+  request["authorization"] = "token #{$github_api_token}"
+  request["accept"] = 'application/vnd.github.v3+json'
+  request["cache-control"] = 'no-cache'
+
+  puts response = http.request(request)
+  puts response.message
+  if response.message != "OK"
+    []
+  else
+    JSON.parse(response.read_body)
+  end
+end

--- a/hooks/ruby/dismiss-review-server/server.rb
+++ b/hooks/ruby/dismiss-review-server/server.rb
@@ -20,7 +20,10 @@ post '/payload' do
 
     # Get branch information
     branch_name = parsed['ref']
-    branch_name.slice!("refs/heads/")
+    removed_slice = branch_name.slice!("refs/heads/")
+    if removed_slice.nil?
+      return "Not a branch. Nothing to do."
+    end
     
     # Get Repository owner
     repo_owner = parsed["repository"]["owner"]["name"]

--- a/hooks/ruby/dismiss-review-server/server.rb
+++ b/hooks/ruby/dismiss-review-server/server.rb
@@ -34,7 +34,7 @@ post '/payload' do
     # that include the branch
     puts pulls_url_filtered = pulls_url.split('{').first + "?head=#{repo_owner}:#{branch_name}"
     url =  URI(pulls_url_filtered)
-    pulls = getPulls(url)
+    pulls = get(url)
 
     # parse pull requests
     if pulls.empty?
@@ -45,7 +45,7 @@ post '/payload' do
         # Get all Reviews for a Pull Request via API
         review_url_orig = pull_request["url"] + "/reviews"
         puts review_url = URI(review_url_orig)
-        reviews = getReviewList(review_url)
+        puts reviews = get(review_url)
 
         reviews.each do |review|
           puts review["state"]
@@ -91,37 +91,18 @@ def put(url)
   end
 end
 
-# https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
-def getReviewList(url)
+def get(url)
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true
   http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
   request = Net::HTTP::Get.new(url)
   request["authorization"] = "token #{$github_api_token}"
+  # Use `application/vnd.github.v3+json` when Reviews is out of preview period
   request["accept"] = 'application/vnd.github.black-cat-preview+json'
   request["cache-control"] = 'no-cache'
 
   response = http.request(request)
-  if response.message != "OK"
-    []
-  else
-    JSON.parse(response.read_body)
-  end
-end
-
-def getPulls(url)
-  http = Net::HTTP.new(url.host, url.port)
-  http.use_ssl = true
-  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-  request = Net::HTTP::Get.new(url)
-  request["authorization"] = "token #{$github_api_token}"
-  request["accept"] = 'application/vnd.github.v3+json'
-  request["cache-control"] = 'no-cache'
-
-  puts response = http.request(request)
-  puts response.message
   if response.message != "OK"
     []
   else

--- a/hooks/ruby/dismiss-review-server/server.rb
+++ b/hooks/ruby/dismiss-review-server/server.rb
@@ -32,7 +32,7 @@ post '/payload' do
     
     # Pull off the {/number}" and search for all Pull Requests
     # that include the branch
-    puts pulls_url_filtered = pulls_url.split('{').first + "?head=#{repo_owner}:#{branch_name}"
+    pulls_url_filtered = pulls_url.split('{').first + "?head=#{repo_owner}:#{branch_name}"
     url =  URI(pulls_url_filtered)
     pulls = get(url)
 
@@ -44,17 +44,16 @@ post '/payload' do
 
         # Get all Reviews for a Pull Request via API
         review_url_orig = pull_request["url"] + "/reviews"
-        puts review_url = URI(review_url_orig)
-        puts reviews = get(review_url)
+        review_url = URI(review_url_orig)
+        reviews = get(review_url)
 
         reviews.each do |review|
-          puts review["state"]
-          review_id = review["id"]
 
-          # Dismiss all Reviews that 'Approved' via API
+          # Dismiss all Reviews in 'APPROVED' state via API
           if review["state"] == "APPROVED"
-            puts "INFO: found an approved"
-            puts dismiss_url = URI(review_url_orig + "/#{review_id}/dismissals")
+            puts "INFO: found an approved Review"
+            review_id = review["id"]
+            dismiss_url = URI(review_url_orig + "/#{review_id}/dismissals")
             put(dismiss_url)
           end
         end.empty? and begin


### PR DESCRIPTION
Modified the [`configuring-your-server`](https://github.com/github/platform-samples/tree/master/hooks/ruby/configuring-your-server) server to listen for `push` webhook events and cancel any `APPROVED` reviews. 

- [x] Still need to clean up get/put methods