### PR TITLE
Add delete repository event webhook

### DIFF
--- a/hooks/ruby/delete-repository-event/Gemfile
+++ b/hooks/ruby/delete-repository-event/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "octokit"

--- a/hooks/ruby/delete-repository-event/Gemfile.lock
+++ b/hooks/ruby/delete-repository-event/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    multipart-post (2.0.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    public_suffix (2.0.5)
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit
+  sinatra
+
+BUNDLED WITH
+   1.14.6

--- a/hooks/ruby/delete-repository-event/README.md
+++ b/hooks/ruby/delete-repository-event/README.md
@@ -1,0 +1,22 @@
+# :x: Delete Repository Event
+
+### :dart: Purpose
+
+This Ruby server:
+
+1. Listens for when a [repository is deleted](https://help.github.com/enterprise/user/articles/deleting-a-repository/) using the [`repository`](https://developer.github.com/enterprise/v3/activity/events/types/#repositoryevent) event and `deleted` action.
+
+2. Creates an issue in `GITHUB_NOTIFICATION_REPOSITORY` as a notification and includes: 
+
+    - a link to restore the repository
+    - the delete repository payload
+
+### :gear: Configuration
+
+1. See the [webhooks](https://developer.github.com/webhooks/) documentation for information on how to [create webhooks](https://developer.github.com/webhooks/creating/) and [configure your server](https://developer.github.com/webhooks/configuring/).
+
+2. Set the following required environment variables:
+
+    - `GITHUB_HOST` - the domain of the GitHub Enterprise instance. e.g. github.example.com
+    - `GITHUB_API_TOKEN` - a [Personal Access Token](https://help.github.com/enterprise/user/articles/creating-a-personal-access-token-for-the-command-line/) that has the ability to create an issue in the notification repository
+    - `GITHUB_NOTIFICATION_REPOSITORY` - the repository in which to create the nofication issue. e.g. github.example.com/administrative-notifications

--- a/hooks/ruby/delete-repository-event/app.rb
+++ b/hooks/ruby/delete-repository-event/app.rb
@@ -32,10 +32,6 @@ end
 # When receiving a webhook for repository deletion (https://developer.github.com/v3/activity/events/types/#repositoryevent)
 #   create an issue in the `github_notification_repository` set by environment variable
 post '/delete-repository-event' do
-  logger.info github_api_token
-  logger.info github_host_url
-  logger.info github_notification_repository
-
   begin
     github_event = request.env['HTTP_X_GITHUB_EVENT']
     if github_event == "repository"

--- a/hooks/ruby/delete-repository-event/app.rb
+++ b/hooks/ruby/delete-repository-event/app.rb
@@ -1,0 +1,61 @@
+# Hook example for notifying an administrator in a repository by creating an issue when a repository is deleted.
+#
+# Needs the following environment variables
+#   GITHUB_HOST - the domain of the GitHub Enterprise instance. e.g. github.example.com
+#   GITHUB_API_TOKEN - a Personal Access Token that has the ability to create an issue in the notification repository.
+#   GITHUB_NOTIFICATION_REPOSITORY - the repository in which to create the nofication issue. e.g.
+#
+# Dependencies:
+#   octokit   - https://github.com/octokit/octokit.rb
+#   sinatrarb - http://www.sinatrarb.com/
+
+require 'octokit'
+require 'sinatra'
+require 'json'
+
+enable :logging
+github_api_token               = ENV['GITHUB_API_TOKEN']
+github_notification_repository = ENV['GITHUB_NOTIFICATION_REPOSITORY']
+github_host_url                = ENV['GITHUB_HOST']
+github_api_endpoint            = "https://#{github_host_url}/api/v3"
+
+Octokit.configure do |c|
+  c.api_endpoint = github_api_endpoint
+  c.access_token = github_api_token
+end
+
+# Needed so that the webhook setup passes
+post '/' do
+  200
+end
+
+# When receiving a webhook for repository deletion (https://developer.github.com/v3/activity/events/types/#repositoryevent)
+#   create an issue in the `github_notification_repository` set by environment variable
+post '/delete-repository-event' do
+  logger.info github_api_token
+  logger.info github_host_url
+  logger.info github_notification_repository
+
+  begin
+    github_event = request.env['HTTP_X_GITHUB_EVENT']
+    if github_event == "repository"
+      request.body.rewind
+      parsed = JSON.parse(request.body.read)
+      action = parsed['action']
+
+      if action == 'deleted'
+        # create a new issue in the repository configured above
+        full_name = parsed['repository']['full_name']
+        purgatory_link = "https://#{github_host_url}/stafftools/users/#{parsed['repository']['owner']['login']}/purgatory"
+        client = Octokit::Client.new
+        client.create_issue(github_notification_repository, "Repository deleted: #{full_name}", "[Restore the repository](#{purgatory_link})\n```json\n#{JSON.pretty_generate(parsed)}\n```")
+
+        return 201,"Repository deleted: #{full_name}, notification created in #{github_notification_repository}"
+      end
+    end
+    return 418, "No such teapot"
+  rescue => e
+    status 500
+    "exception encountered #{e}"
+  end
+end

--- a/hooks/ruby/delete-repository-event/app.rb
+++ b/hooks/ruby/delete-repository-event/app.rb
@@ -16,8 +16,8 @@ require 'json'
 enable :logging
 github_api_token               = ENV['GITHUB_API_TOKEN']
 github_notification_repository = ENV['GITHUB_NOTIFICATION_REPOSITORY']
-github_host_url                = ENV['GITHUB_HOST']
-github_api_endpoint            = "https://#{github_host_url}/api/v3"
+github_host_fqdn               = ENV['GITHUB_HOST']
+github_api_endpoint            = "https://#{github_host_fqdn}/api/v3"
 
 Octokit.configure do |c|
   c.api_endpoint = github_api_endpoint
@@ -42,7 +42,7 @@ post '/delete-repository-event' do
       if action == 'deleted'
         # create a new issue in the repository configured above
         full_name = parsed['repository']['full_name']
-        purgatory_link = "https://#{github_host_url}/stafftools/users/#{parsed['repository']['owner']['login']}/purgatory"
+        purgatory_link = "https://#{github_host_fqdn}/stafftools/users/#{parsed['repository']['owner']['login']}/purgatory"
         client = Octokit::Client.new
         client.create_issue(github_notification_repository, "Repository deleted: #{full_name}", "[Restore the repository](#{purgatory_link})\n```json\n#{JSON.pretty_generate(parsed)}\n```")
 


### PR DESCRIPTION
This webhook will:

- Use the [`RepositoryEvent`](https://developer.github.com/enterprise/v3/activity/events/types/#repositoryevent) [GitHub Enterprise Webhook](https://developer.github.com/enterprise/webhooks/) to listen for `"action": "deleted",`
- Send a notification by creating an issue in a repository when triggered
- Link the archived repository in the issue

cc @azizshamim @ebassias 

To do:

- [x] README.md