### PR TITLE
Pre-receive hook that checks for Jira Issue

### DIFF
--- a/pre-receive-hooks/require-jira-issue.sh
+++ b/pre-receive-hooks/require-jira-issue.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+zero_commit="0000000000000000000000000000000000000000"
+
+read oldrev newrev refname
+echo $oldrev $newrev $refname
+
+check_message_format ()
+# enforced custom commit message format
+{
+  message=`git cat-file commit $newrev | sed '1,/^$/d'`
+  regex="/*\[jira-.*\]"
+  echo "[COMMIT MESSAGE]:" $message
+    if [[  $message =~ $regex ]];
+  then
+    echo "Commit message looks good!"
+    exit 0
+  else
+    echo "[POLICY] Commit message does not contain a JIRA ticket #"
+    exit 1
+
+  fi
+}
+
+if [ "$newrev" = "$zero_commit" ]; then
+  continue
+else
+  check_message_format
+fi

--- a/pre-receive-hooks/require-jira-issue.sh
+++ b/pre-receive-hooks/require-jira-issue.sh
@@ -1,29 +1,19 @@
-#!/usr/bin/env bash
+#!/bin/bash
+#
+# check commit messages for JIRA issue numbers formatted as [JIRA-<issue number>]
 
-zero_commit="0000000000000000000000000000000000000000"
+REGEX="\[JIRA\-[0-9]*\]"
 
-read oldrev newrev refname
-echo $oldrev $newrev $refname
+ERROR_MSG="[POLICY] The commit doesn't reference a JIRA issue"
 
-check_message_format ()
-# enforced custom commit message format
-{
-  message=`git cat-file commit $newrev | sed '1,/^$/d'`
-  regex="/*\[jira-.*\]"
-  echo "[COMMIT MESSAGE]:" $message
-    if [[  $message =~ $regex ]];
-  then
-    echo "Commit message looks good!"
-    exit 0
-  else
-    echo "[POLICY] Commit message does not contain a JIRA ticket #"
-    exit 1
-
-  fi
-}
-
-if [ "$newrev" = "$zero_commit" ]; then
-  continue
-else
-  check_message_format
-fi
+while read OLDREV NEWREV REFNAME ; do
+  for COMMIT in `git rev-list $OLDREV..$NEWREV`;
+  do
+    MESSAGE=`git cat-file commit $COMMIT | sed '1,/^$/d'`
+    if ! echo $MESSAGE | grep -iqE "$REGEX"; then
+      echo "$ERROR_MSG: $MESSAGE" >&2
+      exit 1
+    fi
+  done
+done
+exit 0


### PR DESCRIPTION
This pre-receive hook checks that a Jira issue is present in the commit message. The regex pattern I used is `/*\[jira-.*\]` which would match `[jira-1234]`, for example.

/cc @webdog resident regex guru
/cc @MikeNwin who had the 💡 to add this
/cc @osowskit who helped me on this
/cc @github/solutions-engineering bc ❤️ 

Would love all ya'll's feedback on this 📣🐦 