### PR TITLE
Removing preview media type

### DIFF
--- a/api/ruby/discovering-resources-for-a-user/discovering_organizations.rb
+++ b/api/ruby/discovering-resources-for-a-user/discovering_organizations.rb
@@ -2,8 +2,6 @@ require 'octokit'
 
 Octokit.auto_paginate = true
 
-Octokit.default_media_type = "application/vnd.github.moondragon+json"
-
 # !!! DO NOT EVER USE HARD-CODED VALUES IN A REAL APP !!!
 # Instead, set and test environment variables, like below.
 client = Octokit::Client.new :access_token => ENV["OAUTH_ACCESS_TOKEN"]


### PR DESCRIPTION
Organizations Membership API is out of preview. This is no longer required.