### PR TITLE
Affrae add block_branch_names_not_starting_with_userID.sh

### DIFF
--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -21,7 +21,9 @@ while read oldrev newrev refname; do
     fi
   fi
 done
-echo "Hi, $GITHUB_USER_LOGIN allowing creation of new branch $refname"
+# The following echos may be removed if you like . It's purely a cosmetic demo item
+# To show that it does not have to be just error messages passed back.
+echo "Hi $GITHUB_USER_LOGIN, allowing creation of new branch $refname"
 echo "because it does start with your username ($GITHUB_USER_LOGIN)"
 echo "as outlined in the branch naming policy guide - thank you!"
 exit 0

--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -18,7 +18,7 @@ LC_COLLATE='C'
 while read oldrev newrev refname; do
   # Only check new branches ($oldrev is zero commit), don't block tags
   if [[ $oldrev == $zero_commit && $refname =~ ^refs/heads/ ]]; then
-    # Check if the branch name is lower case characters (ASCII only), '-', '_', "/" or numbers
+    # Check if the branch name begins with the userID - NOTE THIS IS CASE SENSITIVE AT THE MOMENT
     if [[ ! $refname =~ ^refs/heads/$GITHUB_USER_LOGIN ]]; then
       echo "Hi, $GITHUB_USER_LOGIN Blocking creation of new branch $refname"
       echo "because it does not start with your username ($GITHUB_USER_LOGIN)"

--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Pre-receive hook that will block any new commits that their names contain
-# other than lower-case alphabet characters (a-z).
+# Pre-receive hook that will block any new commits that their names do not being with the userID
 #
 # More details on pre-receive hooks and how to apply them can be found on
 # https://help.github.com/enterprise/admin/guides/developer-workflow/managing-pre-receive-hooks-on-the-github-enterprise-appliance/

--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -9,11 +9,6 @@
 
 zero_commit="0000000000000000000000000000000000000000"
 
-# Ensure that [a-z] means only lower case ASCII characters => set LC_COLLATE to 'C'
-# See http://unix.stackexchange.com/questions/227070/why-does-a-z-match-lowercase-letters-in-bash
-# See https://www.gnu.org/software/bash/manual/bashref.html#Pattern-Matching
-LC_COLLATE='C'
-
 while read oldrev newrev refname; do
   # Only check new branches ($oldrev is zero commit), don't block tags
   if [[ $oldrev == $zero_commit && $refname =~ ^refs/heads/ ]]; then

--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -21,8 +21,8 @@ while read oldrev newrev refname; do
     fi
   fi
 done
-# The following echos may be removed if you like . It's purely a cosmetic demo item
-# To show that it does not have to be just error messages passed back.
+# The following echoes may be removed if you like. They are a purely a cosmetic demo item
+# to show that it does not have to be just error messages passed back.
 echo "Hi $GITHUB_USER_LOGIN, allowing creation of new branch $refname"
 echo "because it does start with your username ($GITHUB_USER_LOGIN)"
 echo "as outlined in the branch naming policy guide - thank you!"

--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -21,9 +21,9 @@ while read oldrev newrev refname; do
     fi
   fi
 done
-# The following echoes may be removed if you like. They are a purely a cosmetic demo item
-# to show that it does not have to be just error messages passed back.
-echo "Hi $GITHUB_USER_LOGIN, allowing creation of new branch $refname"
-echo "because it does start with your username ($GITHUB_USER_LOGIN)"
-echo "as outlined in the branch naming policy guide - thank you!"
+# The following echoes may be enabled if you like. They are a purely a cosmetic
+# demo item to show that it does not have to be just error messages passed back.
+# echo "Hi $GITHUB_USER_LOGIN, allowing creation of new branch $refname"
+# echo "because it does start with your username ($GITHUB_USER_LOGIN)"
+# echo "as outlined in the branch naming policy guide - thank you!"
 exit 0

--- a/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
+++ b/pre-receive-hooks/block_branch_names_not_starting_with_userID.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# Pre-receive hook that will block any new commits that their names contain
+# other than lower-case alphabet characters (a-z).
+#
+# More details on pre-receive hooks and how to apply them can be found on
+# https://help.github.com/enterprise/admin/guides/developer-workflow/managing-pre-receive-hooks-on-the-github-enterprise-appliance/
+#
+
+zero_commit="0000000000000000000000000000000000000000"
+
+# Ensure that [a-z] means only lower case ASCII characters => set LC_COLLATE to 'C'
+# See http://unix.stackexchange.com/questions/227070/why-does-a-z-match-lowercase-letters-in-bash
+# See https://www.gnu.org/software/bash/manual/bashref.html#Pattern-Matching
+LC_COLLATE='C'
+
+while read oldrev newrev refname; do
+  # Only check new branches ($oldrev is zero commit), don't block tags
+  if [[ $oldrev == $zero_commit && $refname =~ ^refs/heads/ ]]; then
+    # Check if the branch name is lower case characters (ASCII only), '-', '_', "/" or numbers
+    if [[ ! $refname =~ ^refs/heads/$GITHUB_USER_LOGIN ]]; then
+      echo "Hi, $GITHUB_USER_LOGIN Blocking creation of new branch $refname"
+      echo "because it does not start with your username ($GITHUB_USER_LOGIN)"
+      echo "as outlined in the branch naming policy guide"
+      exit 1
+    fi
+  fi
+done
+echo "Hi, $GITHUB_USER_LOGIN allowing creation of new branch $refname"
+echo "because it does start with your username ($GITHUB_USER_LOGIN)"
+echo "as outlined in the branch naming policy guide - thank you!"
+exit 0


### PR DESCRIPTION
I get asked about branch naming conventions a lot - so I usually show this as a pre-receive hook.

There is one caveat: this comparison is currently case sensitive.