### PR TITLE
add find-inactive-users

### DIFF
--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -28,13 +28,13 @@ export OCTOKIT_ACCESS_TOKEN=00000000000000000000000
 ## Usage
 
 ```shell
-ruby member_audit.rb orgName YYYY-MM-DD
+ruby find_inactive_members.rb orgName YYYY-MM-DD
 ```
 
 or, to automatically remove inactive members
 
 ```shell
-ruby member_audit.rb orgName YYYY-MM-DD purge
+ruby find_inactive_members.rb orgName YYYY-MM-DD purge
 ```
 
 ## How Inactivity is Defined

--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -28,13 +28,13 @@ export OCTOKIT_ACCESS_TOKEN=00000000000000000000000
 ## Usage
 
 ```shell
-ruby find_inactive_members.rb orgName YYYY-MM-DD
+ruby find_inactive_members.rb -o orgName -d YYYY-MM-DD
 ```
 
 or, to automatically remove inactive members
 
 ```shell
-ruby find_inactive_members.rb orgName YYYY-MM-DD purge
+ruby find_inactive_members.rb -o orgName -d YYYY-MM-DD -p
 ```
 
 ## How Inactivity is Defined

--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -1,7 +1,16 @@
 # Find Inactive Organization Members
-> a utility to find, and optionally remove, inactive organization members
 
-This utility finds users inactive since a configured date, writes those users to a file `inactive_users.csv`, and optionally removes them from the organization
+```
+find_inactive_members.rb - Find and output inactive members in an organization
+    -c, --check                      Check connectivity and scope
+    -d, --date MANDATORY             Date from which to start looking for activity
+    -e, --email                      Fetch the user email (can make the script take longer
+    -o, --organization MANDATORY     Organization to scan for inactive users
+    -v, --verbose                    More output to STDERR
+    -h, --help                       Display this help
+```
+
+This utility finds users inactive since a configured date, writes those users to a file `inactive_users.csv`.
 
 ## Installation
 
@@ -20,27 +29,23 @@ gem install octokit
 
 ### Configure Octokit
 
+The `OCTOKIT_ACCESS_TOKEN` is required in order to see activities on private repositories. However the `OCTOKIT_API_ENDPOINT` isn't required if connecting to GitHub.com, but is required if connecting to a GitHub Enterprise instance.
+
 ```shell
-export OCTOKIT_API_ENDPOINT="https://github.example.com/api/v3" # Default: "https://api.github.com"
-export OCTOKIT_ACCESS_TOKEN=00000000000000000000000
+export OCTOKIT_ACCESS_TOKEN=00000000000000000000000     # Required if looking for activity in private repositories.
+export OCTOKIT_API_ENDPOINT="https://<your_github_enterprise_instance>/api/v3" # Not required if connecting to GitHub.com.
 ```
 
 ## Usage
 
-```shell
-ruby find_inactive_members.rb -o orgName -d YYYY-MM-DD
 ```
-
-or, to automatically remove inactive members
-
-```shell
-ruby find_inactive_members.rb -o orgName -d YYYY-MM-DD -p
+ruby find_active_members.rb [-cehv] -o ORGANIZATION -d DATE
 ```
 
 ## How Inactivity is Defined
 
-Members are defined as inactive if:
+Members are defined as inactive if they haven't, since the specified **DATE**,  in any repository in the specified **ORGANIZATION**:
 
-* They have not committed to the default branch of a repository in the org since the `YYYY-MM-DD`
-* They have not opened an issue or PR that has had activity since the `YYYY-MM-DD`
-* They have not commented on an issue or PR since the `YYYY-MM-DD`
+* Have not merged or pushed commits into the default branch
+* Have not opened an Issue or Pull Request
+* Have not commented on an Issue or Pull Request

--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -1,0 +1,46 @@
+# Find Inactive Organization Members
+> a utility to find, and optionally remove, inactive organization members
+
+This utility finds users inactive since a configured date, writes those users to a file `inactive_users.csv`, and optionally removes them from the organization
+
+## Installation
+
+### Clone this repository
+
+```shell
+git clone https://github.com/github/platform-samples.git
+cd api/ruby/find-inactive-members
+```
+
+### Install dependencies
+
+```shell
+gem install octokit
+```
+
+### Configure Octokit
+
+```shell
+export OCTOKIT_API_ENDPOINT="https://github.example.com/api/v3" # Default: "https://api.github.com"
+export OCTOKIT_ACCESS_TOKEN=00000000000000000000000
+```
+
+## Usage
+
+```shell
+ruby member_audit.rb orgName YYYY-MM-DD
+```
+
+or, to automatically remove inactive members
+
+```shell
+ruby member_audit.rb orgName YYYY-MM-DD purge
+```
+
+## How Inactivity is Defined
+
+Members are defined as inactive if:
+
+* They have not committed to a repository in the org since the `SINCE_DATE`
+* They have not opened an issue or PR that has had activity since the `SINCE_DATE`
+* They have not commented on an issue or PR since the `SINCE_DATE`

--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -41,6 +41,6 @@ ruby find_inactive_members.rb orgName YYYY-MM-DD purge
 
 Members are defined as inactive if:
 
-* They have not committed to a repository in the org since the `SINCE_DATE`
-* They have not opened an issue or PR that has had activity since the `SINCE_DATE`
-* They have not commented on an issue or PR since the `SINCE_DATE`
+* They have not committed to a repository in the org since the `YYYY-MM-DD`
+* They have not opened an issue or PR that has had activity since the `YYYY-MM-DD`
+* They have not commented on an issue or PR since the `YYYY-MM-DD`

--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -41,6 +41,6 @@ ruby find_inactive_members.rb orgName YYYY-MM-DD purge
 
 Members are defined as inactive if:
 
-* They have not committed to a repository in the org since the `YYYY-MM-DD`
+* They have not committed to the default branch of a repository in the org since the `YYYY-MM-DD`
 * They have not opened an issue or PR that has had activity since the `YYYY-MM-DD`
 * They have not commented on an issue or PR since the `YYYY-MM-DD`

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -101,8 +101,8 @@ CSV.open("inactive_users.csv", "wb") do |csv|
       puts "#{member["login"]} is inactive"
       csv << [member["login"]]
       if ARGV[2] == "purge"
-        puts "removing the member"
-        # @client.remove_organization_member(ORGANIZATION, member["login"])
+        puts "removing #{member["login"]}"
+        @client.remove_organization_member(ORGANIZATION, member["login"])
       end
     end
   end

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -78,13 +78,21 @@ end
   end
 
   # get all issue comments after specified date and iterate
-  print "...comments"
+  print "...issue comments"
   @client.issues_comments(repo["full_name"], { :since => ARGV[1]}).each do |comment|
     # if commenter is a member of the org and not active, make active
     if t = @members.find {|member| member["login"] == comment["user"]["login"] && member["active"] == false }
       make_active(t["login"])
     end
+  end
 
+  # get all pull request comments comments after specified date and iterate
+  print "...issue comments"
+  @client.pull_requests_comments(repo["full_name"], { :since => ARGV[1]}).each do |comment|
+    # if commenter is a member of the org and not active, make active
+    if t = @members.find {|member| member["login"] == comment["user"]["login"] && member["active"] == false }
+      make_active(t["login"])
+    end
   end
 
   # print update to terminal

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -45,9 +45,8 @@ OptionParser.new do |opts|
 end.parse!
 
 raise(OptionParser::MissingArgument) if (
-  options[:organization].nil? and
-  options[:date].nil? and
-  options[:p].nil? )
+  options[:organization].nil? or
+  options[:date].nil?)
 
 stack = Faraday::RackBuilder.new do |builder|
   builder.use Octokit::Middleware::FollowRedirects

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -25,6 +25,7 @@ class InactiveMemberSearch
 
     @date = options[:date]
     @organization = options[:organization]
+    @email = options[:email]
 
     organization_members
     organization_repositories
@@ -73,13 +74,17 @@ private
     $stdout.print message
   end
 
+  def member_email(login)
+    @email ? @client.user(login)[:email] : ""
+  end
+
   def organization_members
   # get all organization members and place into an array of hashes
     @members = @client.organization_members(@organization).collect do |m|
-      email = @client.user(m[:login])[:email]
+      email = 
       {
         login: m["login"],
-        email: email,
+        email: member_email(m[:login]),
         active: false
       }
     end
@@ -204,6 +209,10 @@ OptionParser.new do |opts|
 
   opts.on('-d', '--date MANDATORY',Date, "Date from which to start looking for activity") do |d|
     options[:date] = d.to_s
+  end
+
+  opts.on('-e', '--email', "Fetch the user email (can make the script take longer") do |e|
+    options[:email] = e
   end
 
   opts.on('-o', '--organization MANDATORY',String, "Organization to scan for inactive users") do |o|

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -118,33 +118,45 @@ private
   def issue_activity(repo, date=@date)
     # get all issues after specified date and iterate
     info "...issues"
-    @client.list_issues(repo, { :since => date }).each do |issue|
-      # if creator is a member of the org and not active, make active
-      if t = @members.find {|member| member[:login] == issue["user"]["login"] && member[:active] == false }
-        make_active(t[:login])
+    begin
+      @client.list_issues(repo, { :since => date }).each do |issue|
+        # if creator is a member of the org and not active, make active
+        if t = @members.find {|member| member[:login] == issue["user"]["login"] && member[:active] == false }
+          make_active(t[:login])
+        end
       end
+    rescue
+      info "... no issues to check"
     end
   end
 
   def issue_comment_activity(repo, date=@date)
     # get all issue comments after specified date and iterate
     info "...issue comments"
-    @client.issues_comments(repo, { :since => date}).each do |comment|
-      # if commenter is a member of the org and not active, make active
-      if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
-        make_active(t[:login])
+    begin
+      @client.issues_comments(repo, { :since => date}).each do |comment|
+        # if commenter is a member of the org and not active, make active
+        if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
+          make_active(t[:login])
+        end
       end
+    rescue
+      info "...no issues comments to check"
     end
   end
 
   def pr_activity(repo, date=@date)
     # get all pull request comments comments after specified date and iterate
     info "...pr comments"
-    @client.pull_requests_comments(repo, { :since => date}).each do |comment|
-      # if commenter is a member of the org and not active, make active
-      if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
-        make_active(t[:login])
+    begin
+      @client.pull_requests_comments(repo, { :since => date}).each do |comment|
+        # if commenter is a member of the org and not active, make active
+        if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
+          make_active(t[:login])
+        end
       end
+    rescue
+      info "...no pr comments to check"
     end
   end
 

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -3,6 +3,8 @@ require "octokit"
 require 'optparse'
 require 'optparse/date'
 
+SCOPES=["read:org", "read:user", "repo", "user:email"]
+
 def env_help
   output=<<-EOM
 Required Environment variables:
@@ -67,7 +69,7 @@ def info(message)
 end
 
 def check_scopes
-  info "Scopes #{@client.scopes.join ','}\n"
+  info "Scopes: #{@client.scopes.join ','}\n"
 end
 
 def check_app
@@ -81,7 +83,7 @@ def get_auth_token(login, password, otp)
   res = temp_client.create_authorization(
     {
       :idempotent => true,
-      :scopes => ["read:org", "read:user", "repo", "user:email"],
+      :scopes => SCOPES,
       :headers => {'X-GitHub-OTP' => otp}
     })
   res[:token]

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -135,7 +135,7 @@ private
     info "...Issues"
     @client.list_issues(repo, { :since => date }).each do |issue|
       # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
-      if comment["user"].nil?
+      if issue["user"].nil?
         next
       end
       # if creator is a member of the org and not active, make active

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -42,7 +42,7 @@ class InactiveMemberSearch
   end
 
   def check_rate_limit
-    info "Rate limit: #{client.rate_limit}\n"
+    info "Rate limit: #{@client.rate_limit.remaining}/#{@client.rate_limit.limit}\n"
   end
 
   def env_help

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -1,0 +1,110 @@
+require "octokit"
+require "csv"
+
+if ARGV.length > 3 || ARGV.length == 0
+  puts "usage: ruby find_inactive_members.rb orgName YYYY-MM-DD purge(optional)"
+  exit(1)
+end
+
+if ARGV[2] == "purge"
+  print "Do you really want to purge all members of #{ARGV[0]} inactive since #{ARGV[1]}? y/n: "
+  response = STDIN.gets.chomp
+  if response != "y"
+    exit(1)
+  end
+end
+
+# initialize octokit
+Octokit.auto_paginate = true
+@client = Octokit::Client.new
+
+# get all organization members and place into an array of hashes
+@members = []
+@client.organization_members(ARGV[0]).each do |member|
+  hsh = {}
+  hsh["login"] = member["login"]
+  hsh["active"] = false
+  @members << hsh
+end
+
+# get all repos in the organizaton and place into a hash
+@repos = []
+@client.organization_repositories(ARGV[0]).each do |repo|
+  hsh = {}
+  hsh["full_name"] = repo["full_name"]
+  @repos << hsh
+end
+
+@total_repos = @repos.length
+@total_members = @members.length
+
+# print update to terminal
+puts "\n"
+puts "Analying activity for #{@total_members} members and #{@total_repos} repos in #{ARGV[0]}"
+
+@repos_completed = 0
+
+# method to switch member status to active
+def make_active(login)
+  hsh = @members.find { |member| member["login"] == login }
+  hsh["active"] = true
+end
+
+# for each repo
+@repos.each do |repo|
+
+  print "analyzing #{repo["full_name"]}"
+
+  # get all commits after specified date and iterate
+  print "...commits"
+  begin
+    @client.commits_since(repo["full_name"], ARGV[1]).each do |commit|
+      # if commmitter is a member of the org and not active, make active
+      if t = @members.find {|member| member["login"] == commit["author"]["login"] && member["active"] == false }
+        make_active(t["login"])
+      end
+    end
+  rescue
+    print "...skipping blank repo"
+  end
+
+  # get all issues after specified date and iterate
+  print "...issues"
+  @client.list_issues(repo["full_name"], { :since => ARGV[1] }).each do |issue|
+    # if creator is a member of the org and not active, make active
+    if t = @members.find {|member| member["login"] == issue["user"]["login"] && member["active"] == false }
+      make_active(t["login"])
+    end
+  end
+
+  # get all issue comments after specified date and iterate
+  print "...comments"
+  @client.issues_comments(repo["full_name"], { :since => ARGV[1]}).each do |comment|
+    # if commenter is a member of the org and not active, make active
+    if t = @members.find {|member| member["login"] == comment["user"]["login"] && member["active"] == false }
+      make_active(t["login"])
+    end
+
+  end
+
+  # print update to terminal
+  @repos_completed += 1
+  print "...#{@repos_completed}/#{@total_repos} repos completed\n"
+
+end
+
+# open a new csv for output
+CSV.open("inactive_users.csv", "wb") do |csv|
+  # iterate and print inactive members
+  @members.each do |member|
+    if member["active"] == false
+      puts "#{member["login"]} is inactive"
+      csv << [member["login"]]
+      if ARGV[2] == "purge"
+        puts "removing the member"
+        # @client.remove_organization_member(ORGANIZATION, member["login"])
+      end
+    end
+  end
+
+end

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -6,17 +6,10 @@ require 'optparse/date'
 def env_help
   output=<<-EOM
 Required Environment variables:
-  GITHUB_TOKEN: A valid personal access token with Organzation admin priviliges
-  GITHUB_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL (Defaults to https://api.github.com)
+  OCTOKIT_ACCESS_TOKEN: A valid personal access token with Organzation admin priviliges
+  OCTOKIT_API_ENDPOINT: A valid GitHub/GitHub Enterprise API endpoint URL (Defaults to https://api.github.com)
 EOM
   output
-end
-
-begin
-  ACCESS_TOKEN = ENV.fetch("GITHUB_TOKEN")
-  API_ENDPOINT = ENV.fetch("GITHUB_API_ENDPOINT", "https://api.github.com")
-rescue KeyError
-  puts env_help 
 end
 
 options = {}
@@ -57,8 +50,6 @@ stack = Faraday::RackBuilder.new do |builder|
 end
 
 Octokit.configure do |kit|
-  kit.api_endpoint = API_ENDPOINT
-  kit.access_token = ACCESS_TOKEN
   kit.auto_paginate = true
   # kit.middleware = stack
 end

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -14,6 +14,7 @@ class InactiveMemberSearch
     if options[:check]
       check_app
       check_scopes
+      check_rate_limit
       exit 0
     end
 
@@ -37,6 +38,10 @@ class InactiveMemberSearch
 
   def check_scopes
     info "Scopes: #{@client.scopes.join ','}\n"
+  end
+
+  def check_rate_limit
+    info "Rate limit: #{client.rate_limit}\n"
   end
 
   def env_help

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -3,7 +3,6 @@ require "octokit"
 require 'optparse'
 require 'optparse/date'
 
-
 class InactiveMemberSearch
   attr_accessor :organization, :members, :repositories, :date, :unrecognized_authors
 
@@ -129,46 +128,34 @@ private
 
   def issue_activity(repo, date=@date)
     # get all issues after specified date and iterate
-    info "...issues"
-    begin
-      @client.list_issues(repo, { :since => date }).each do |issue|
-        # if creator is a member of the org and not active, make active
-        if t = @members.find {|member| member[:login] == issue["user"]["login"] && member[:active] == false }
-          make_active(t[:login])
-        end
+    info "...Issues"
+    @client.list_issues(repo, { :since => date }).each do |issue|
+      # if creator is a member of the org and not active, make active
+      if t = @members.find {|member| member[:login] == issue["user"]["login"] && member[:active] == false }
+        make_active(t[:login])
       end
-    rescue
-      info "... no issues to check"
     end
   end
 
   def issue_comment_activity(repo, date=@date)
     # get all issue comments after specified date and iterate
-    info "...issue comments"
-    begin
-      @client.issues_comments(repo, { :since => date}).each do |comment|
-        # if commenter is a member of the org and not active, make active
-        if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
-          make_active(t[:login])
-        end
+    info "...Issue comments"
+    @client.issues_comments(repo, { :since => date}).each do |comment|
+      # if commenter is a member of the org and not active, make active
+      if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
+        make_active(t[:login])
       end
-    rescue
-      info "...no issues comments to check"
     end
   end
 
   def pr_activity(repo, date=@date)
     # get all pull request comments comments after specified date and iterate
-    info "...pr comments"
-    begin
-      @client.pull_requests_comments(repo, { :since => date}).each do |comment|
-        # if commenter is a member of the org and not active, make active
-        if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
-          make_active(t[:login])
-        end
+    info "...Pull Request comments"
+    @client.pull_requests_comments(repo, { :since => date}).each do |comment|
+      # if commenter is a member of the org and not active, make active
+      if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
+        make_active(t[:login])
       end
-    rescue
-      info "...no pr comments to check"
     end
   end
 

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -86,8 +86,10 @@ raise(OptionParser::MissingArgument) if (
 
 # get all organization members and place into an array of hashes
 @members = @client.organization_members(options[:organization]).collect do |m|
+  email = @client.user(m[:login])[:email]
   { 
     login: m["login"],
+    email: email,
     active: false
   }
 end
@@ -166,8 +168,9 @@ CSV.open("inactive_users.csv", "wb") do |csv|
   # iterate and print inactive members
   @members.each do |member|
     if member[:active] == false
-      puts "#{member[:login]} is inactive"
-      csv << [member[:login]]
+      member_detail = "#{member[:login]} <#{member[:email] unless member[:email].nil?}>"
+      info "#{member_detail} is inactive"
+      csv << [member_detail]
       if false # ARGV[2] == "purge"
         info "removing #{member[:login]}\n"
         @client.remove_organization_member(ORGANIZATION, member[:login])

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -87,7 +87,7 @@ end
   end
 
   # get all pull request comments comments after specified date and iterate
-  print "...issue comments"
+  print "...pr comments"
   @client.pull_requests_comments(repo["full_name"], { :since => ARGV[1]}).each do |comment|
     # if commenter is a member of the org and not active, make active
     if t = @members.find {|member| member["login"] == comment["user"]["login"] && member["active"] == false }

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -144,7 +144,7 @@ private
   def issue_comment_activity(repo, date=@date)
     # get all issue comments after specified date and iterate
     info "...Issue comments"
-    @client.issues_comments(repo, { :since => date}).each do |comment|
+    @client.issues_comments(repo, { :since => date }).each do |comment|
       # if commenter is a member of the org and not active, make active
       if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
         make_active(t[:login])
@@ -155,7 +155,11 @@ private
   def pr_activity(repo, date=@date)
     # get all pull request comments comments after specified date and iterate
     info "...Pull Request comments"
-    @client.pull_requests_comments(repo, { :since => date}).each do |comment|
+    @client.pull_requests_comments(repo, { :since => date }).each do |comment|
+      # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
+      if comment["user"].nil?
+        next
+      end
       # if commenter is a member of the org and not active, make active
       if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
         make_active(t[:login])

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -80,6 +80,7 @@ private
 
   def organization_members
   # get all organization members and place into an array of hashes
+    info "Finding #{@organization} members "
     @members = @client.organization_members(@organization).collect do |m|
       email = 
       {
@@ -92,11 +93,12 @@ private
   end
 
   def organization_repositories
+    info "Gathering a list of repositories..."
     # get all repos in the organizaton and place into a hash
     @repositories = @client.organization_repositories(@organization).collect do |repo|
       repo["full_name"]
     end
-    info "#{@repositories.length} repositories found.\n"
+    info "#{@repositories.length} repositories discovered\n"
   end
 
   # method to switch member status to active

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -176,10 +176,6 @@ private
           member_detail = "#{member[:login]} <#{member[:email] unless member[:email].nil?}>"
           info "#{member_detail} is inactive\n"
           csv << [member_detail]
-          if false # ARGV[2] == "purge"
-            info "removing #{member[:login]}\n"
-            @client.remove_organization_member(ORGANIZATION, member[:login])
-          end
         end
       end
     end
@@ -200,10 +196,6 @@ OptionParser.new do |opts|
 
   opts.on('-o', '--organization MANDATORY',String, "Organization to scan for inactive users") do |o|
     options[:organization] = o
-  end
-
-  opts.on('-p', '--purge', "Purge the inactive members (WARNING - DESTRUCTIVE!)") do |p|
-    options[:purge] = p
   end
 
   opts.on('-v', '--verbose', "More output to STDERR") do |v|

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -132,6 +132,7 @@ info "Analyzing activity for #{@members.length} members and #{repos.length} repo
 
 # for each repo
 repos.each do |repo|
+  info "rate limit remaining: #{@client.rate_limit.remaining}  "
   info "analyzing #{repo}"
 
   # get all commits after specified date and iterate

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -71,10 +71,24 @@ def check_scopes
 end
 
 def check_app
-  info "Application client/secret? #{Octokit.client.application_authenticated?}"
+  info "Application client/secret? #{Octokit.client.application_authenticated?}\n"
+  info "Authentication Token? #{Octokit.client.token_authenticated?}\n"
+end
+
+# helper to get an auth token for the OAuth application and a user
+def get_auth_token(login, password, otp)
+  temp_client = Octokit::Client.new(login: login, password: password)
+  res = temp_client.create_authorization(
+    {
+      :idempotent => true,
+      :scopes => ["read:org", "read:user", "repo", "user:email"],
+      :headers => {'X-GitHub-OTP' => otp}
+    })
+  res[:token]
 end
 
 if options[:check]
+  check_app
   check_scopes
   exit 0
 end

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -107,7 +107,7 @@ private
     hsh[:active] = true
   end
 
-  def commit_activity(repository)
+  def commit_activity(repo)
     # get all commits after specified date and iterate
     info "...commits"
     @client.commits_since(repo, @date).each do |commit|

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -110,15 +110,11 @@ private
   def commit_activity(repository)
     # get all commits after specified date and iterate
     info "...commits"
-    begin
-      @client.commits_since(repo, @date).each do |commit|
-        # if commmitter is a member of the org and not active, make active
-        if t = @members.find {|member| member[:login] == commit["author"]["login"] && member[:active] == false }
-          make_active(t[:login])
-        end
+    @client.commits_since(repo, @date).each do |commit|
+      # if commmitter is a member of the org and not active, make active
+      if t = @members.find {|member| member[:login] == commit["author"]["login"] && member[:active] == false }
+        make_active(t[:login])
       end
-    rescue
-      info "...skipping blank repo"
     end
   end
 

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -134,6 +134,10 @@ private
     # get all issues after specified date and iterate
     info "...Issues"
     @client.list_issues(repo, { :since => date }).each do |issue|
+      # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
+      if comment["user"].nil?
+        next
+      end
       # if creator is a member of the org and not active, make active
       if t = @members.find {|member| member[:login] == issue["user"]["login"] && member[:active] == false }
         make_active(t[:login])
@@ -145,6 +149,10 @@ private
     # get all issue comments after specified date and iterate
     info "...Issue comments"
     @client.issues_comments(repo, { :since => date }).each do |comment|
+      # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
+      if comment["user"].nil?
+        next
+      end
       # if commenter is a member of the org and not active, make active
       if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
         make_active(t[:login])

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -67,7 +67,7 @@ def info(message)
 end
 
 def check_scopes
-  puts @client.scopes.join ','
+  info "Scopes #{@client.scopes.join ','}\n"
 end
 
 def check_app
@@ -94,14 +94,14 @@ raise(OptionParser::MissingArgument) if (
   }
 end
 
-info "#{@members.length} members found."
+info "#{@members.length} members found.\n"
 
 # get all repos in the organizaton and place into a hash
 repos = @client.organization_repositories(options[:organization]).collect do |repo|
   repo["full_name"]
 end
 
-info "#{repos.length} repositories found."
+info "#{repos.length} repositories found.\n"
 
 # method to switch member status to active
 def make_active(login)
@@ -169,7 +169,7 @@ CSV.open("inactive_users.csv", "wb") do |csv|
   @members.each do |member|
     if member[:active] == false
       member_detail = "#{member[:login]} <#{member[:email] unless member[:email].nil?}>"
-      info "#{member_detail} is inactive"
+      info "#{member_detail} is inactive\n"
       csv << [member_detail]
       if false # ARGV[2] == "purge"
         info "removing #{member[:login]}\n"


### PR DESCRIPTION
This PR adds a ruby utility to find inactive users in an organization and, optionally, remove them.

It was inspired/necessitated by https://github.com/github/solutions-engineering/issues/5102

As it is based on Octokit.rb (and thereby the REST v3 API) it has the potential to get quite chatty with larger organizations and may require a temporary bump in the API rate limit if using .com

For a full understanding of how it is designed to work, check out the [rendered README](https://github.com/github/platform-samples/blob/find-inactive-members/api/ruby/find-inactive-members/README.md)