### PR TITLE
Bug in restrict-master-to-gui-merges.sh allows merge to master

### DIFF
--- a/pre-receive-hooks/restrict-master-to-gui-merges.sh
+++ b/pre-receive-hooks/restrict-master-to-gui-merges.sh
@@ -5,14 +5,14 @@
 DEFAULT_BRANCH=$(git symbolic-ref HEAD)
 while read -r oldrev newrev refname; do
   if [[ "${refname}" != "${DEFAULT_BRANCH:=refs/heads/master}" ]]; then
-    exit 0
+    continue
   else
     if [[ "${GITHUB_VIA}" != 'pull request merge button' && \
           "${GITHUB_VIA}" != 'pull request merge api' ]]; then
       echo "Changes to the default branch must be made by Pull Request. Direct pushes, edits, or merges are not allowed."
       exit 1
     else
-      exit 0
+      continue
     fi
   fi
 done


### PR DESCRIPTION
There is a bug in `restrict-master-to-gui-merges.sh` that can be exploited to allow you push to master.  All you have to do is push multiple ref updates in one go:

```
$ git push origin HEAD:something HEAD:master     

Counting objects: 1, done.
Writing objects: 100% (1/1), 178 bytes | 0 bytes/s, done.
Total 1 (delta 0), reused 0 (delta 0)
To <internal>:dfox/demo-repo.git
   7611f36..b8b8786  HEAD -> master
   7611f36..b8b8786  HEAD -> something

$ git rev-parse origin/master

b8b8786e915374f91805b8fc4aebc3091f9aed73
```

## Why does this happen?

The script's use of `exit 0` means it jumps out of the `while` loop and never checks any further refs if the first one is deemed to be valid.  Switching to use `continue` ensures that the script goes round the loop until there's no more input, when it will finally exit 0.

I discovered this while writing a suite of junit tests for these scripts (as I wanted to add some extra functionality without breaking things).  I'm guessing you don't want a whole ton of extra CI overhead, but in case you're interested, this is the specific failing test that exposed the issue:

```java
@Test
public void deny_any_push_that_touches_master() throws Exception {
    assertThat(repo.bash().run(script)
            .stdin("unused unused refs/heads/some-feature-branch")
            .stdin("unused unused refs/heads/master")
            .stdin("unused unused refs/heads/even-more")
            .stdin("unused unused refs/tags/1.0.0")
            .waitForExit().exitValue()).isEqualTo(1);
}
```