### PR TITLE
Changing rest_client to rest-client

### DIFF
--- a/api/ruby/basics-of-authentication/server.rb
+++ b/api/ruby/basics-of-authentication/server.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-require 'rest_client'
+require 'rest-client'
 require 'json'
 
 # !!! DO NOT EVER USE HARD-CODED VALUES IN A REAL APP !!!


### PR DESCRIPTION
I am going through the setup https://developer.github.com/v3/guides/basics-of-authentication and noticed this small typo.