### PR TITLE
Fix syntax error in commit-current-user-check.sh

### DIFF
--- a/pre-receive-hooks/commit-current-user-check.sh
+++ b/pre-receive-hooks/commit-current-user-check.sh
@@ -20,7 +20,7 @@ TOKEN=USER:TOKEN
 # We set the address of the GHE Instance here
 GHE_URL=https://GHE-INSTANCE
 
-GITHUB_USER_EMAIL=`curl -s -k -u ${TOKEN} ${GHE URL}/api/v3/users/${GITHUB_USER_LOGIN} | grep email | sed 's/  \"email\"\: \"//' | sed 's/\",//'`
+GITHUB_USER_EMAIL=`curl -s -k -u ${TOKEN} ${GHE_URL}/api/v3/users/${GITHUB_USER_LOGIN} | grep email | sed 's/  \"email\"\: \"//' | sed 's/\",//'`
 
 if echo "${GITHUB_USER_EMAIL}" | grep "null,"
 then


### PR DESCRIPTION
The variable "GHE_URL" was quoted incorrectly as "GHE URL"