### PR TITLE
Explicitly check for subdomain isolation to make sure all URLs work

### DIFF
--- a/graphql/enterprise/index.html
+++ b/graphql/enterprise/index.html
@@ -173,14 +173,16 @@
 
         const hostnames = location.hostname.split('.')
 
-        if (hostnames[0] === "pages") {
-          // subdomain isolation enabled, so remove the first part of the URL
-          hostnames.shift()
-          const apiHost = location.protocol + '//' + hostnames.join('.')
-        } else {
-          // no subdomain isolation
-          const apiHost = location.protocol + '//' + location.hostname
-        }
+        const apiHost = function () {
+         if (hostnames[0] === "pages") {
+           // subdomain isolation enabled, so remove the first part of the URL
+           hostnames.shift()
+           return location.protocol + '//' + hostnames.join('.')
+         } else {
+           // no subdomain isolation
+           return location.protocol + '//' + location.hostname
+         }
+       }()
 
         return fetch(apiHost + '/api/graphql', {
           method: 'post',

--- a/graphql/enterprise/index.html
+++ b/graphql/enterprise/index.html
@@ -171,9 +171,10 @@
       function graphQLFetcher(graphQLParams) {
         // Determine the API URL for this GitHub Enterprise server
 
+        const hostnames = location.hostname.split('.')
+
         if (hostnames[0] === "pages") {
-          // subdomain isolation enabled
-          const hostnames = location.hostname.split('.')
+          // subdomain isolation enabled, so remove the first part of the URL
           hostnames.shift()
           const apiHost = location.protocol + '//' + hostnames.join('.')
         } else {

--- a/graphql/enterprise/index.html
+++ b/graphql/enterprise/index.html
@@ -170,13 +170,22 @@
       // as long as it returns a Promise or Observable.
       function graphQLFetcher(graphQLParams) {
         // Determine the API URL for this GitHub Enterprise server
-        const hostnames = location.hostname.split('.')
-        const apiHost = location.protocol + '//' + hostnames[hostnames.length - 2] + '.' + hostnames[hostnames.length - 1]
+
+        if (hostnames[0] === "pages") {
+          // subdomain isolation enabled
+          const hostnames = location.hostname.split('.')
+          hostnames.shift()
+          const apiHost = location.protocol + '//' + hostnames.join('.')
+        } else {
+          // no subdomain isolation
+          const apiHost = location.protocol + '//' + location.hostname
+        }
+
         return fetch(apiHost + '/api/graphql', {
           method: 'post',
           headers: {
             'Accept': 'application/json',
-            'Authorization': 'Basic ' + authToken,
+            'Authorization': 'Bearer ' + authToken,
             'Content-Type': 'application/json'
           },
           mode: 'cors',


### PR DESCRIPTION
Fixes #174 

The way this was constructing the API URL before was not very scalable. There are use cases where hostnames can be much longer than normal. This explicitly checks to see if GraphiQL is being served from the `pages` subdomain, which mans subdomain isolation is enabled. Otherwise, the regular `location.hostname` will be the right URL.