### PR TITLE
Rejects pushes where static assets are changed

### DIFF
--- a/pre-receive-hooks/block_static_asset_modified.sh
+++ b/pre-receive-hooks/block_static_asset_modified.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# this script will exit with non-0 when a static content file is modified
+#   new static file objects are fine, as well as deleting files
+
+# grab the command line args -- read from standard input
+while read oldrev newrev refname; do
+
+	# do a git difference between the master branch and the new one going to be added
+	#  if a file is modified, assert it's not a static file (image or font)
+	count=0
+	while read -r line; do
+		if [[ $line == M* ]] ; then # the line starts with M, meaning file modified
+
+			# extract the filename, the 3rd character on
+			filename=${line:2}
+
+			# test regex for image / font file extensions -- use bash since it has regex built in
+			if [[ $filename =~ (\.png)|(\.jpg)|(\.jpeg)|(\.gif)|(\.tiff)|(\.otf)|(\.eot)|(\.ttf)|(\.svg)|(\.woff) ]] ; then
+				echo "error" $filename "was modified, and that file represents a static file!"
+				((count++))
+			fi
+		fi
+	done <<< `git diff --name-status master...$newrev`
+	if [[ $count != 0 ]]; then
+		echo "You changed "$count" static file(s)."
+		echo "Create new files instead of changing them. (Due to cache settings.)"
+		echo "View all files changed using this:"
+		echo "git diff --name-status master..."$newrev
+		exit 1
+	fi
+done
+# good status, exit normally
+exit 0


### PR DESCRIPTION
My team recently increased the cache time of static assets (images & fonts), and we'd like to make it so you can't push code that modifies these files. (only new filenames can be created)

My team uses a pattern of creating branches from the original repo, and then PR's for the branches into master.

#### Testing
##### Setup
  - Create local repo on computer using ```git init --bare```
     - this one will be the destination repo
  - Create another local repo using git init in another folder
     - make the origin reference to the repo with the destination repo
  - push some files to master
  - Copy this hook into hooks/pre-receive on the destination repo, make sure to give it +x permission
###### File change
 - make a new branch ```git checkout -b test```
 - make an image file change, and push it
 - remote should reject the push
 - revert the file (using git checkout master FILENAME)
   - remote should accept the push now