### PR TITLE
Fixing issue with ruby gem 'activesupport' not found

### DIFF
--- a/app/ruby/app-issue-creator/Gemfile
+++ b/app/ruby/app-issue-creator/Gemfile
@@ -4,3 +4,4 @@ gem "json",        "~> 1.8"
 gem 'sinatra',     '~> 1.3.5'
 gem 'octokit'
 gem 'jwt'
+gem 'activesupport', '~> 5.0'


### PR DESCRIPTION
This fixes issue #211, the Gemfile lacks a gem reference.