### PR TITLE
GitHub OAuth Example in Go

### DIFF
--- a/api/golang/basics-of-authentication/README.md
+++ b/api/golang/basics-of-authentication/README.md
@@ -1,0 +1,30 @@
+# basics-of-authentication
+
+This is the sample project built by following the "[Basics of Authentication][basics of auth]"
+guide on developer.github.com - ported to Go.
+
+As the Go standard library does not come with built-in web session handling, only the [simple example](https://github.com/github/platform-samples/blob/master/api/ruby/basics-of-authentication/server.rb) was ported. The example also shows how to use the [GitHub golang SDK](https://github.com/google/go-github).
+
+## Install and Run project
+
+First, of all, you would need to [follow the steps](https://developer.github.com/v3/guides/basics-of-authentication/#registering-your-app) in the GitHub OAuth Developer Guide to register an OAuth application with callback URL `http://localhost:4567/callback`.
+
+Copy the client id and the secret of your newly created app and set them as environmental variables:
+
+`export GH_BASIC_SECRET_ID=<application secret>`
+
+`export GH_BASIC_CLIENT_ID=<client id>`
+
+Make sure you have Go [installed](https://golang.org/doc/install); then retrieve the modules needed for the [go-github client library](https://github.com/google/go-github) by running
+
+`go get github.com/google/go-github/github` and
+
+`go get golang.org/x/oauth2` on the command line.
+
+Finally, type `go run server.go` on the command line.
+
+This command will run the server at `localhost:4567`. Visit `http://localhost:4567` with your browser to get your GitHub email addresses revealed (after authorizing the GitHub OAuth App).
+
+If you should get any errors while redirecting to GitHub, double check your environmental variables and the callback URL you set while registering your OAuth app.
+
+[basics of auth]: http://developer.github.com/guides/basics-of-authentication/

--- a/api/golang/basics-of-authentication/server.go
+++ b/api/golang/basics-of-authentication/server.go
@@ -92,6 +92,8 @@ type Access struct {
 
 var indexPageData = IndexPageData{clientId}
 
+var background = context.Background()
+
 func main() {
 	http.HandleFunc("/", index)
 	http.HandleFunc("/callback", basic)
@@ -137,13 +139,13 @@ func basic(w http.ResponseWriter, r *http.Request) {
 
 	client := getGitHubClient(access.AccessToken)
 
-	user, _, err := client.Users.Get(context.Background(), "")
+	user, _, err := client.Users.Get(background, "")
 	if err != nil {
 		log.Println("Could not list user details: ", err)
 		return
 	}
 
-	emails, _, err := client.Users.ListEmails(context.Background(), nil)
+	emails, _, err := client.Users.ListEmails(background, nil)
 	if err != nil {
 		log.Println("Could not list user emails: ", err)
 		return
@@ -159,7 +161,7 @@ func basic(w http.ResponseWriter, r *http.Request) {
 
 // Authenticates GitHub Client with provided OAuth access token
 func getGitHubClient(accessToken string) *github.Client {
-	ctx := context.Background()
+	ctx := background
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: accessToken},
 	)

--- a/api/golang/basics-of-authentication/server.go
+++ b/api/golang/basics-of-authentication/server.go
@@ -1,0 +1,168 @@
+/*
+ * Port of server.rb from GitHub "Basics of authentication" developer guide
+ * https://developer.github.com/v3/guides/basics-of-authentication/
+ *
+ * Simple OAuth server retrieving all email adresses of the GitHub user who authorizes this GitHub OAuth Application
+ */
+
+// Simple OAuth server retrieving the email adresses of a GitHub user.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+//!+template
+import "html/template"
+
+/*
+ * Do not forget to set those two environmental variables from the GitHub OAuth App settings
+ */
+var clientId = os.Getenv("GH_BASIC_CLIENT_ID")
+var clientSecret = os.Getenv("GH_BASIC_SECRET_ID")
+
+var indexPage = template.Must(template.New("indexPage").Parse(`
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+  <head>
+
+  </head>
+	<body>
+		<p>Well, hello there!</p>
+			<p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}">Click here</a> to begin!</a></p>
+			<p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
+	</body>
+</html>
+`))
+
+var basicPage = template.Must(template.New("basicPage").Parse(`
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+  <head>
+
+  </head>
+  <body>
+    <p>Hello, {{.User.Login}}</p>
+    <p>
+			{{if not .User.Email}}
+				It looks like you don't have a public email. That's cool.
+			{{else}}
+				It looks like your public email address is {{.User.Email}}.
+			{{end}}
+    </p>
+    <p>
+      {{if not .Emails}}
+				Also, you're a bit secretive about your private email addresses.
+			{{else}}
+				With your permission, we were also able to dig up your private email addresses:
+      	{{range .Emails}}
+					<p>{{.Email}} (verified: {{.Verified}})</p>
+					{{end}}
+			{{end}}
+    </p>
+  </body>
+</html>
+`))
+
+//!-template
+
+type IndexPageData struct {
+	ClientId string
+}
+
+type BasicPageData struct {
+	User   *github.User
+	Emails []*github.UserEmail
+}
+
+type Access struct {
+	AccessToken string `json:"access_token"`
+	Scope       string
+}
+
+var indexPageData = IndexPageData{clientId}
+
+func main() {
+	http.HandleFunc("/", index)
+	http.HandleFunc("/callback", basic)
+	log.Fatal(http.ListenAndServe("localhost:4567", nil))
+}
+
+func index(w http.ResponseWriter, r *http.Request) {
+	if err := indexPage.Execute(w, indexPageData); err != nil {
+		log.Println(err)
+	}
+}
+
+func basic(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	values := url.Values{"client_id": {clientId}, "client_secret": {clientSecret}, "code": {code}, "accept": {"json"}}
+
+	req, _ := http.NewRequest("POST", "https://github.com/login/oauth/access_token", strings.NewReader(values.Encode()))
+	req.Header.Set(
+		"Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Println("Retrieving access token failed: ", resp.Status)
+		return
+	}
+	var access Access
+
+	if err := json.NewDecoder(resp.Body).Decode(&access); err != nil {
+		log.Println("JSON-Decode-Problem: ", err)
+		return
+	}
+
+	if access.Scope != "user:email" {
+		log.Println("Wrong token scope: ", access.Scope)
+		return
+	}
+
+	client := getGitHubClient(access.AccessToken)
+
+	user, _, err := client.Users.Get(context.Background(), "")
+	if err != nil {
+		log.Println("Could not list user details: ", err)
+		return
+	}
+
+	emails, _, err := client.Users.ListEmails(context.Background(), nil)
+	if err != nil {
+		log.Println("Could not list user emails: ", err)
+		return
+	}
+
+	basicPageData := BasicPageData{User: user, Emails: emails}
+
+	if err := basicPage.Execute(w, basicPageData); err != nil {
+		log.Println(err)
+	}
+
+}
+
+// Authenticates GitHub Client with provided OAuth access token
+func getGitHubClient(accessToken string) *github.Client {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: accessToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	return github.NewClient(tc)
+}

--- a/api/golang/basics-of-authentication/server.go
+++ b/api/golang/basics-of-authentication/server.go
@@ -29,52 +29,8 @@ import "html/template"
 var clientId = os.Getenv("GH_BASIC_CLIENT_ID")
 var clientSecret = os.Getenv("GH_BASIC_SECRET_ID")
 
-var indexPage = template.Must(template.New("indexPage").Parse(`
-<!DOCTYPE html>
-<meta charset="utf-8">
-<html>
-  <head>
-
-  </head>
-	<body>
-		<p>Well, hello there!</p>
-			<p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}">Click here</a> to begin!</a></p>
-			<p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
-	</body>
-</html>
-`))
-
-var basicPage = template.Must(template.New("basicPage").Parse(`
-<!DOCTYPE html>
-<meta charset="utf-8">
-<html>
-  <head>
-
-  </head>
-  <body>
-    <p>Hello, {{.User.Login}}</p>
-    <p>
-			{{if not .User.Email}}
-				It looks like you don't have a public email. That's cool.
-			{{else}}
-				It looks like your public email address is {{.User.Email}}.
-			{{end}}
-    </p>
-    <p>
-      {{if not .Emails}}
-				Also, you're a bit secretive about your private email addresses.
-			{{else}}
-				With your permission, we were also able to dig up your private email addresses:
-      	{{range .Emails}}
-					<p>{{.Email}} (verified: {{.Verified}})</p>
-					{{end}}
-			{{end}}
-    </p>
-  </body>
-</html>
-`))
-
-//!-template
+var indexPage = template.Must(template.New("index.tmpl").ParseFiles("views/index.tmpl"))
+var basicPage = template.Must(template.New("basic.tmpl").ParseFiles("views/basic.tmpl"))
 
 type IndexPageData struct {
 	ClientId string

--- a/api/golang/basics-of-authentication/views/basic.tmpl
+++ b/api/golang/basics-of-authentication/views/basic.tmpl
@@ -10,20 +10,20 @@
 	<p>Hello, {{.User.Login}}</p>
 	<p>
 		{{if not .User.Email}}
-		It looks like you don't have a public email. That's cool.
+		  It looks like you don't have a public email. That's cool.
 		{{else}}
 			It looks like your public email address is {{.User.Email}}.
-			{{end}}
+		{{end}}
 	</p>
 	<p>
 		{{if not .Emails}}
-		Also, you're a bit secretive about your private email addresses.
+		  Also, you're a bit secretive about your private email addresses.
 		{{else}}
 			With your permission, we were also able to dig up your private email addresses:
 			{{range .Emails}}
-			<p>{{.Email}} (verified: {{.Verified}})</p>
+			   <p>{{.Email}} (verified: {{.Verified}})</p>
 			{{end}}
-			{{end}}
+		{{end}}
 	</p>
 </body>
 

--- a/api/golang/basics-of-authentication/views/basic.tmpl
+++ b/api/golang/basics-of-authentication/views/basic.tmpl
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+  <head>
+
+  </head>
+  <body>
+    <p>Hello, {{.User.Login}}</p>
+    <p>
+			{{if not .User.Email}}
+				It looks like you don't have a public email. That's cool.
+			{{else}}
+				It looks like your public email address is {{.User.Email}}.
+			{{end}}
+    </p>
+    <p>
+      {{if not .Emails}}
+				Also, you're a bit secretive about your private email addresses.
+			{{else}}
+				With your permission, we were also able to dig up your private email addresses:
+      	{{range .Emails}}
+					<p>{{.Email}} (verified: {{.Verified}})</p>
+					{{end}}
+			{{end}}
+    </p>
+  </body>
+</html>

--- a/api/golang/basics-of-authentication/views/basic.tmpl
+++ b/api/golang/basics-of-authentication/views/basic.tmpl
@@ -10,18 +10,18 @@
 	<p>Hello, {{.User.Login}}</p>
 	<p>
 		{{if not .User.Email}}
-		  It looks like you don't have a public email. That's cool.
+      It looks like you don't have a public email. That's cool.
 		{{else}}
 			It looks like your public email address is {{.User.Email}}.
 		{{end}}
 	</p>
 	<p>
 		{{if not .Emails}}
-		  Also, you're a bit secretive about your private email addresses.
+      Also, you're a bit secretive about your private email addresses.
 		{{else}}
 			With your permission, we were also able to dig up your private email addresses:
 			{{range .Emails}}
-			   <p>{{.Email}} (verified: {{.Verified}})</p>
+        <p>{{.Email}} (verified: {{.Verified}})</p>
 			{{end}}
 		{{end}}
 	</p>

--- a/api/golang/basics-of-authentication/views/basic.tmpl
+++ b/api/golang/basics-of-authentication/views/basic.tmpl
@@ -1,27 +1,30 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <html>
-  <head>
 
-  </head>
-  <body>
-    <p>Hello, {{.User.Login}}</p>
-    <p>
-			{{if not .User.Email}}
-				It looks like you don't have a public email. That's cool.
-			{{else}}
-				It looks like your public email address is {{.User.Email}}.
+<head>
+
+</head>
+
+<body>
+	<p>Hello, {{.User.Login}}</p>
+	<p>
+		{{if not .User.Email}}
+		It looks like you don't have a public email. That's cool.
+		{{else}}
+			It looks like your public email address is {{.User.Email}}.
 			{{end}}
-    </p>
-    <p>
-      {{if not .Emails}}
-				Also, you're a bit secretive about your private email addresses.
-			{{else}}
-				With your permission, we were also able to dig up your private email addresses:
-      	{{range .Emails}}
-					<p>{{.Email}} (verified: {{.Verified}})</p>
-					{{end}}
+	</p>
+	<p>
+		{{if not .Emails}}
+		Also, you're a bit secretive about your private email addresses.
+		{{else}}
+			With your permission, we were also able to dig up your private email addresses:
+			{{range .Emails}}
+			<p>{{.Email}} (verified: {{.Verified}})</p>
 			{{end}}
-    </p>
-  </body>
+			{{end}}
+	</p>
+</body>
+
 </html>

--- a/api/golang/basics-of-authentication/views/index.tmpl
+++ b/api/golang/basics-of-authentication/views/index.tmpl
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <html>
-  <head>
-  </head>
-	<body>
-		<p>Well, hello there!</p>
-			<p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}">Click here</a> to begin!</a></p>
-			<p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
-	</body>
+
+<head>
+</head>
+
+<body>
+	<p>Well, hello there!</p>
+	<p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}">Click here</a> to begin!</a></p>
+	<p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
+</body>
+
 </html>

--- a/api/golang/basics-of-authentication/views/index.tmpl
+++ b/api/golang/basics-of-authentication/views/index.tmpl
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+  <head>
+  </head>
+	<body>
+		<p>Well, hello there!</p>
+			<p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}">Click here</a> to begin!</a></p>
+			<p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
+	</body>
+</html>


### PR DESCRIPTION
# basics-of-authentication

This is the sample project built by following the "[Basics of Authentication][basics of auth]"
guide on developer.github.com - ported to Go.

As the Go standard library does not come with built-in web session handling, only the [simple example](https://github.com/github/platform-samples/blob/master/api/ruby/basics-of-authentication/server.rb) was ported. The example also shows how to use the [GitHub golang SDK](https://github.com/google/go-github).

## Install and Run project

First, of all, you would need to [follow the steps](https://developer.github.com/v3/guides/basics-of-authentication/#registering-your-app) in the GitHub OAuth Developer Guide to register an OAuth application with callback URL `http://localhost:4567/callback`.

Copy the client id and the secret of your newly created app and set them as environmental variables:

`export GH_BASIC_SECRET_ID=<application secret>`

`export GH_BASIC_CLIENT_ID=<client id>`

Make sure you have Go [installed](https://golang.org/doc/install); then retrieve the modules needed for the [go-github client library](https://github.com/google/go-github) by running

`go get github.com/google/go-github/github` and

`go get golang.org/x/oauth2` on the command line.

Finally, type `go run server.go` on the command line.

This command will run the server at `localhost:4567`. Visit `http://localhost:4567` with your browser to get your GitHub email addresses revealed (after authorizing the GitHub OAuth App).

If you should get any errors while redirecting to GitHub, double check your environmental variables and the callback URL you set while registering your OAuth app.

[basics of auth]: http://developer.github.com/guides/basics-of-authentication/
