### PR TITLE
Create branches-and-commits-by-repository.graphql

### DIFF
--- a/graphql/queries/branches-and-commits-by-repository.graphql
+++ b/graphql/queries/branches-and-commits-by-repository.graphql
@@ -1,0 +1,36 @@
+query getCommitsByBranchByRepo($org:String!, $repo:String!) {
+  organization(login:$org) {
+    name
+    repository(name:$repo) {
+      name
+      refs(refPrefix: "refs/heads/", first: 10) {
+        nodes {
+          id
+          name
+          target {
+            ... on Commit {
+              history(first: 100) {
+                nodes {
+                  messageHeadline
+                  committedDate
+                  author {
+                    name
+                    email
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added a query with pagination support to list all refs for a repository and the commits on those refs.