### PR TITLE
allow fast forward pushes

### DIFF
--- a/pre-receive-hooks/restrict-master-to-gui-merges.sh
+++ b/pre-receive-hooks/restrict-master-to-gui-merges.sh
@@ -7,12 +7,10 @@ while read -r oldrev newrev refname; do
   if [[ "${refname}" != "${DEFAULT_BRANCH:=refs/heads/master}" ]]; then
     continue
   else
-    if [[ "${GITHUB_VIA}" != 'pull request merge button' && \
-          "${GITHUB_VIA}" != 'pull request merge api' ]]; then
-      echo "Changes to the default branch must be made by Pull Request. Direct pushes, edits, or merges are not allowed."
-      exit 1
-    else
-      continue
-    fi
+    test "${GITHUB_VIA}" == 'pull request merge button' && continue
+    test "${GITHUB_VIA}" == 'pull request merge api' && continue
+
+    echo "Changes to the default branch must be made by Pull Request. Direct pushes, edits, or merges are not allowed."
+    exit 1
   fi
 done

--- a/pre-receive-hooks/restrict-master-to-gui-merges.sh
+++ b/pre-receive-hooks/restrict-master-to-gui-merges.sh
@@ -9,6 +9,8 @@ while read -r oldrev newrev refname; do
   else
     test "${GITHUB_VIA}" == 'pull request merge button' && continue
     test "${GITHUB_VIA}" == 'pull request merge api' && continue
+    
+    test 0 -eq "$(git rev-list --count ${DEFAULT_BRANCH}...${newref})" && continue
 
     echo "Changes to the default branch must be made by Pull Request. Direct pushes, edits, or merges are not allowed."
     exit 1


### PR DESCRIPTION
- :hammer: early returns to allow for more checks
- allow fast forward merges for `restrict-master-to-gui-merges` in the event that there are more than one core branches (e.g. master, develop, release)