### PR TITLE
Update find_inactive_members.rb

### DIFF
--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -127,6 +127,9 @@ private
       end
     rescue Octokit::Conflict
       info "...no commits"
+    rescue Octokit::NotFound
+      #API responds with a 404 (instead of an empty set) when the `commits_since` range is out of bounds of commits.
+      info "...no commits"
     end
   end
 


### PR DESCRIPTION
Add error handling for the null set response which GitHub's API treats as an entity not existing error and responds with a 404 instead of an empty set.

/cc @MikeNwin @harsh 