### PR TITLE
improve performance of require-jira-issue.sh

### DIFF
--- a/pre-receive-hooks/require-jira-issue.sh
+++ b/pre-receive-hooks/require-jira-issue.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 #
-# check commit messages for JIRA issue numbers formatted as [JIRA-<issue number>]
-
-REGEX="\[JIRA\-[0-9]*\]"
+# check commit messages for JIRA issue numbers formatted as JIRA-<issue number> for any project e.g. FT-1097
+#
+# Can check which commit messages (of the last however-many) would not be allowed:
+# git log -n 10000 --pretty=format:%s | grep -vE "^(Merge|.*[A-Z]+\-[0-9]+)" | sort -u
 
 ERROR_MSG="[POLICY] The commit doesn't reference a JIRA issue"
 
 while read OLDREV NEWREV REFNAME ; do
-  for COMMIT in `git rev-list $OLDREV..$NEWREV`;
-  do
-    MESSAGE=`git cat-file commit $COMMIT | sed '1,/^$/d'`
-    if ! echo $MESSAGE | grep -iqE "$REGEX"; then
-      echo "$ERROR_MSG: $MESSAGE" >&2
+  STARTING_COMMIT=$OLDREV
+  if [ "$OLDREV" == "0000000000000000000000000000000000000000" ]; then
+    STARTING_COMMIT="refs/heads/master"
+  fi
+  
+  message=$(git log --pretty=format:"%s %b -~-" $STARTING_COMMIT..$NEWREV | \
+      awk 'BEGIN{RS="-~-\n"; found=0 } !/^(Merge|.*[A-Z]+-[0-9]+)/ {print NR, $0; found=1;} END{exit found}')
+
+  if [ $? -ne 0 ]
+  then
+      echo "$ERROR_MSG: $message" >&2
       exit 1
-    fi
-  done
-done
+  fi
+done  
+
 exit 0


### PR DESCRIPTION
If you have a repo with a lot of activity, a branch can quickly fall behind. After a certain number of commits (about 1000) the shell loop will be too slow to run in the 5s timeout, so its not possible to merge from upstream branch intoyour own branch and push it.

Using a delimiter in the git log, and then awk means all the commits can be considered by a single command pipeline.

1000 commits timing:
previous:  5.32s (too much)
new: 0.052s (quick enough)
