### PR TITLE
Link to org security alerts script example

### DIFF
--- a/api/javascript/enable-org-security-alerts.md
+++ b/api/javascript/enable-org-security-alerts.md
@@ -1,0 +1,7 @@
+## Enable Security Alerts for an Organization
+
+The linked repository below contains sample scripts for Node and Bash which can be used to enable security alerts and automated security fixes in all of the repositories in a given organization. 
+
+This project is a being provided as a sample only which illustrates how to [enable vulnerability alerts](https://developer.github.com/v3/repos/#enable-vulnerability-alerts) and [enable automated security fixes](https://developer.github.com/v3/repos/#enable-automated-security-fixes) in all repositories in a given organization.
+
+Please see repo https://github.com/github/enable-security-alerts-sample for both the Node and Bash scripts, and instructions to execute them. 


### PR DESCRIPTION
GitHub's product and services teams got together to write a script that enables security vulnerability alerts all at once for a given organization. This helps organizations that predate the launch of vulnerability alerts catch up with enabling them on all of their repositories at once. This file links to the public repository where they are maintained under an MIT license. 

Examples provided are in both Node and Bash. The v3 (REST) APIs used are currently in preview at this time and we expect support for GitHub Enterprise Server as early as GHES 2.18.