### PR TITLE
add script `git-find-stale-branches`

### DIFF
--- a/scripts/git-find-stale-branches
+++ b/scripts/git-find-stale-branches
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Find unmerged branches that haven't been modified for more than a year.
+#
+# # Why would you do this?
+#
+# Although branches are cheap in Git, they can clutter the repository in
+# large quantities. Unmerged branches also might introduce large files
+# that are unnecessarily kept in the repository. If those branches get
+# deleted, than Git can cleanup those files automatically.
+#
+# Usage:
+# git-find-stale-branches
+#
+# Author: Lars Schneider, https://github.com/larsxschneider
+#
+
+[[ $(git rev-parse --is-bare-repository) == true ]] || remote=--remote
+
+git branch --list --no-merged $(git symbolic-ref --short HEAD) $remote \
+	--sort=committerdate \
+	--format='%(refname:short) (%(committerdate:relative))' \
+| grep '([[:digit:]]* year.* ago)'


### PR DESCRIPTION
Find unmerged branches that haven't been modified for more than a year.

### Why would you do this?

Although branches are cheap in Git, they can clutter the repository in
large quantities. Unmerged branches also might introduce large files
that are unnecessarily kept in the repository. If those branches get
deleted, than Git can cleanup those files automatically.

If you are curious, here is the result for this repo:
```
$ git-find-stale-branches
origin/add-shell-scripts (4 years, 2 months ago)
origin/gjtorikian-patch-1 (2 years, 2 months ago)
origin/org-users-and-collaborators (1 year, 5 months ago)
origin/graphql/issue-utils (1 year, 2 months ago)
origin/primetheus/pre-commit (1 year, 2 months ago)
```

/cc @github/services-devops-engineers 