### PR TITLE
improve git-purge-files script

### DIFF
--- a/scripts/git-purge-files
+++ b/scripts/git-purge-files
@@ -29,7 +29,7 @@ DESCRIPTION
 
 OPTIONS
        <path-regex>...
-           A list of regular expression that defines what files should
+           A list of regular expressions that defines what files should
            be purged from the history. Use a `/` to anchor a path to the
            root of the repository.
 

--- a/scripts/git-purge-files
+++ b/scripts/git-purge-files
@@ -1,46 +1,142 @@
 #!/usr/bin/perl
 #
-# Purge files from Git repositories.
-#
-# Attention:
-#     You want to run this script on a case sensitive file-system (e.g.
-#     ext4 on Linux). Otherwise the resulting Git repository will not
-#     contain changes that modify the casing of file paths.
-#
-# Usage:
-#     git-purge-files [path-regex1] [path-regex2] ...
-#
-# Examples:
-#    Remove the file "test.bin" from all directories:
-#    git-purge-path "/test.bin$"
-#
-#    Remove all "*.bin" files from all directories:
-#    git-purge-path "\.bin$"
-#
-#    Remove all files in the "/foo" directory:
-#    git-purge-path "^/foo/$"
-#
-# Author: Lars Schneider, https://github.com/larsxschneider
+# Purge files from Git repositories
 #
 
+use 5.010;
 use strict;
 use warnings;
+use Getopt::Std;
+use File::Temp qw/ tempdir /;
 
-my $path_regex = join( "|", @ARGV );
+sub usage() {
+    print STDERR <<END;
+NAME
+       git-purge-files - Purge files from Git repositories
 
-open( my $pipe_in, "git fast-export --progress=10000 --no-data --all --signed-tags=warn-strip --tag-of-filtered-object=rewrite |" ) or die $!;
-open( my $pipe_out, "| git fast-import --force --quiet" ) or die $!;
+SYNOPSIS
+       git-purge-files [-c] [-d] [-h] [<path-regex>] ...
 
-LOOP: while ( my $cmd = <$pipe_in> ) {
-    my $data = "";
-    if ( $cmd =~ /^data ([0-9]+)$/ ) {
-        # skip data blocks
-        my $skip_bytes = $1;
-        read($pipe_in, $data, $skip_bytes);
+
+DESCRIPTION
+       This command purges files from a Git history by rewriting all
+       commits. Please note that this changes all commit hashes in the
+       history and therefore all branches and tags.
+
+       You want to run this script on a case sensitive file-system (e.g.
+       ext4 on Linux). Otherwise the resulting Git repository will not
+       contain changes that modify the casing of file paths.
+
+OPTIONS
+       <path-regex>...
+           A list of regular expression that defines what files should
+           be purged from the history. Use a `/` to anchor a path to the
+           root of the repository.
+
+       -c
+           Run in checking mode. The script will run the underlaying
+           `git fast-export | git fast-import` command without any
+           modifications to the data stream. Afterwards the input
+           repository is compared against the output repository.
+
+           ATTENTION: Although we run a check here, the repository
+                      under test is rewritten and potentially modified!
+
+       -d
+           Enable diff mode. This makes the underlaying `git fast-export`
+           output only the file differences between two commits. This
+           mode is quicker but more error prone. It is not recommended
+           in production usage.
+
+           See examples for potential problems here:
+           https://public-inbox.org/git/CABPp-BFLJ48BZ97Y9mr4i3q7HMqjq18cXMgSYdxqD1cMzH8Spg\@mail.gmail.com/
+
+       -h
+           This help.
+
+EXAMPLES
+       o   Remove the file "test.bin" from all directories:
+
+               \$ git-purge-path "/test.bin$"
+
+       o   Remove all "*.bin" files from all directories:
+
+               \$ git-purge-path "\.bin$"
+
+       o   Remove all files in the "/foo" directory:
+
+               \$ git-purge-path "^/foo/$"
+END
+    exit(1);
+}
+
+our($opt_h, $opt_d, $opt_c);
+getopts("hdc") or usage();
+usage if $opt_h;
+
+# TODO: Git 2.23 will likely have a "--reencode=no" option that we want add here
+my $export_opts = "--all --no-data --progress=1000 --signed-tags=warn-strip --tag-of-filtered-object=rewrite --use-done-feature";
+my $import_opts = "--done --force --quiet";
+
+if (not $opt_d) {
+    $export_opts .= " --full-tree";
+}
+
+if ($opt_c) {
+    say "Checking 'git fast-export | git fast-import' pipeline... ";
+
+    # Print the changed files, author, committer, branches, and commit message
+    # for every commit of the Git repository. We intentionally do not output
+    # and compare any hashes here as commit and tree hashes can change due to
+    # slightly different object serialization methods in older Git clients.
+    # E.g. directories have been encoded as 40000 instead of 04000 for a brief
+    # period in ~2009 and "git fast-export | git fast-import" would fix that
+    # which would lead to different hashes.
+    my $git_log = "git log --all --numstat --full-history --format='%nauthor:    %an <%ae> %at%ncommitter: %cn <%ce> %ct%nbranch:    %S%nbody:      %B%n%n---' --no-renames";
+    my $tmp = tempdir('git-purge-files-XXXXX', TMPDIR => 1);
+
+    if (
+      system("$git_log > $tmp/expected") or
+      system("git fast-export $export_opts | git fast-import $import_opts") or
+      system("$git_log > $tmp/result") or
+      system("diff $tmp/expected $tmp/result")
+    ) {
+        say "";
+        say "Failure! Rewriting the repository with `git-purge-files` might alter the history.";
+        say "Inspect the following files to review the difference:";
+        say " - $tmp/expected";
+        say " - $tmp/result";
+        say "Try to omit the `-d` option!" if ($opt_d);
+        exit 1;
+    } else {
+        say "Success!";
+        exit 0;
+
     }
-    elsif ( $cmd =~ /^M [0-9]{6} [0-9a-f]{40} (.+)$/ ) {
-        my $pathname = $1;
-        next LOOP if ("/" . $pathname) =~ /$path_regex/o
+} else {
+    say "Purging files...\n";
+
+    exit 0 if (@ARGV == 0);
+    my $path_regex = join( "|", @ARGV );
+    my $start_time = time;
+
+    open( my $pipe_in, "git fast-export $export_opts |" ) or die $!;
+    open( my $pipe_out, "| git fast-import $import_opts" ) or die $!;
+
+    LOOP: while ( my $cmd = <$pipe_in> ) {
+        my $data = "";
+        if ( $cmd =~ /^data ([0-9]+)$/ ) {
+            # skip data blocks
+            my $skip_bytes = $1;
+            read($pipe_in, $data, $skip_bytes);
+        }
+        elsif ( $cmd =~ /^M [0-9]{6} [0-9a-f]{40} (.+)$/ ) {
+            my $pathname = $1;
+            next LOOP if ("/" . $pathname) =~ /$path_regex/o
+        }
+        print {$pipe_out} $cmd . $data;
     }
-    print {$pipe_out} $cmd . $data;
+
+    my $duration = time - $start_time;
+    say "Done! Execution time: $duration s";
 }

--- a/scripts/git-purge-files
+++ b/scripts/git-purge-files
@@ -39,6 +39,10 @@ OPTIONS
            modifications to the data stream. Afterwards the input
            repository is compared against the output repository.
 
+           For large repositories we recommend to run this script in
+           checking mode (-c) mode first in order to determine if it can
+           run in the much faster diff mode (-d) mode.
+
            ATTENTION: Although we run a check here, the repository
                       under test is rewritten and potentially modified!
 

--- a/scripts/git-purge-files
+++ b/scripts/git-purge-files
@@ -6,6 +6,7 @@
 use 5.010;
 use strict;
 use warnings;
+use version;
 use Getopt::Std;
 use File::Temp qw/ tempdir /;
 
@@ -78,13 +79,15 @@ our($opt_h, $opt_d, $opt_c);
 getopts("hdc") or usage();
 usage if $opt_h;
 
-# TODO: Git 2.23 will likely have a "--reencode=no" option that we want add here
-my $export_opts = "--all --no-data --progress=1000 --signed-tags=warn-strip --tag-of-filtered-object=rewrite --use-done-feature";
-my $import_opts = "--done --force --quiet";
+my ($git_version) = `git --version` =~ /([0-9]+([.][0-9]+)+)/;
 
-if (not $opt_d) {
-    $export_opts .= " --full-tree";
-}
+my $export_opts = "--all --no-data --progress=1000 --signed-tags=warn-strip --tag-of-filtered-object=rewrite --use-done-feature";
+$export_opts .= " --reencode=no" if (version->parse($git_version) ge version->parse('2.23.0'));
+$export_opts .= " --full-tree" if (not $opt_d);
+
+print $export_opts;
+
+my $import_opts = "--done --force --quiet";
 
 if ($opt_c) {
     say "Checking 'git fast-export | git fast-import' pipeline... ";

--- a/scripts/tests/t0001-git-purge-symlinks
+++ b/scripts/tests/t0001-git-purge-symlinks
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+out=/dev/null
+
+function test_expect_success {
+    if ! eval "$* >$out"; then
+        echo "FAILURE: $(basename "${BASH_SOURCE[0]}: $*")"
+        exit 1
+    fi
+}
+
+function test_expect_failure {
+    if eval "$* >$out"; then
+        echo "SUCCESS although FAILURE expected: $(basename "${BASH_SOURCE[0]}: $*")"
+        exit 1
+    fi
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/..">/dev/null && pwd)"
+test_dir="$script_dir/tmp"
+
+rm -rf "$test_dir"
+mkdir "$test_dir"
+pushd "$test_dir" >/dev/null
+
+    git init -q .
+
+    mkdir foo
+    echo "foo" >foo/baz
+    git add .
+    git commit -qm "add foo dir with file"
+
+    ln -s foo bar
+    git add .
+    git commit -qm "add bar dir as link"
+
+    rm bar
+    mkdir bar
+    echo "bar" >bar/baz
+    git add .
+    git commit -qm "remove link and make bar dir real"
+
+    test_expect_success ../git-purge-files -c
+
+popd >/dev/null
+
+rm -rf "$test_dir"
+mkdir "$test_dir"
+pushd "$test_dir" >/dev/null
+
+    git init -q .
+
+    mkdir foo
+    echo "foo" >foo/baz
+    git add .
+    git commit -qm "add foo dir with file"
+
+    ln -s foo bar
+    git add .
+    git commit -qm "add bar dir as link"
+
+    rm bar
+    mkdir bar
+    echo "bar" >bar/baz
+    git add .
+    git commit -qm "remove link and make bar dir real"
+
+    # see https://public-inbox.org/git/95EF0665-9882-4707-BB6A-94182C01BE91@gmail.com/
+    test_expect_failure ../git-purge-files -c -d
+
+popd >/dev/null


### PR DESCRIPTION
Unfortunately, the `git-purge-files` script could change the Git history in [unintended ways](https://public-inbox.org/git/95EF0665-9882-4707-BB6A-94182C01BE91@gmail.com/) if multiple path names with the same name would be touched in a single commit. I modfied the script and instructed `git fast-export` to write out the entire tree (`--full-tree` option) instead of just the changed files by default. This should work around this problem although it will increase the run time significantly. You can get the old behavior with the new `-d` switch (`d` means `diff` here).

In addition I added a help page, measured execution time, and added a simple test case.

/cc @github/services-devops-engineers