### PR TITLE
Pre-receive hook to block commits by size under 50MB

### DIFF
--- a/pre-receive-hooks/block_by_file_size.sh
+++ b/pre-receive-hooks/block_by_file_size.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+#
+# Pre-receive hook that will block any new commits that contain a file, or the whole commit, that is larger than size in bytes
+MAX_SIZE=100000
+
+#
+# More details on pre-receive hooks and how to apply them can be found on
+# https://help.github.com/enterprise/admin/guides/developer-workflow/managing-pre-receive-hooks-on-the-github-enterprise-appliance/
+#
+
+while read oldrev newrev refname; do
+  # Looking at total commit size
+  TOTAL=0
+  
+  for SIZE in `git rev-list $oldrev..$newrev --objects --all \
+              | git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
+              | sed -n 's/^blob //p' \
+              | sort --numeric-sort --key=2 \
+              | cut -d " " -f 2`
+  do 
+     if [ ${SIZE} -gt ${MAX_SIZE} ]
+     then
+        echo "Error: File sized at ${SIZE} bytes is in a commit. The maximum allowed is ${MAX_SIZE} bytes."
+        exit 1
+     fi
+     
+     # Now check total commit size and exit immediatly if it fails.
+     TOTAL=$(($TOTAL + $SIZE))
+     if [ ${TOTAL} -gt ${MAX_SIZE} ]
+     then
+        echo "Error: The commit ${newrev} is ${TOTAL} bytes or more. The maximum allowed is ${MAX_SIZE} bytes."
+        exit 2
+     fi
+  done
+done
+
+exit 0


### PR DESCRIPTION
Pre-receive hook to block commits smaller than repo Maximum Object Size setting.

We had a requirement from a user to block any file and any commit that was over 100000 bytes in size.

Obviously the **Maximum Object Size** setting would be useful for this:
> Set the maximum size of Git objects that can be pushed to this repository.
> Allowing large objects to be pushed into Git can degrade performance, consider other options
> (e.g. git-lfs) before increasing this value. 

However, as the minimum value that can be set is 50 MB this was not the way forward.

So knocked up this pre-receive hook. Not sure that it is the most efficient way of doing things, but it seems to work OK.

