### PR TITLE
Add more information on OCTOKIT_ACCESS_TOKEN to README.md

### DIFF
--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -29,7 +29,7 @@ gem install octokit
 
 ### Configure Octokit
 
-The `OCTOKIT_ACCESS_TOKEN` is required in order to see activities on private repositories. However the `OCTOKIT_API_ENDPOINT` isn't required if connecting to GitHub.com, but is required if connecting to a GitHub Enterprise instance.
+The `OCTOKIT_ACCESS_TOKEN` is required in order to see activities on private repositories. Also note that GitHub.com has an rate limit of 60 unauthenticated requests per hour, which this tool can easily exceed. Access tokens can be generated at https://github.com/settings/tokens. The `OCTOKIT_API_ENDPOINT` isn't required if connecting to GitHub.com, but is required if connecting to a GitHub Enterprise instance.
 
 ```shell
 export OCTOKIT_ACCESS_TOKEN=00000000000000000000000     # Required if looking for activity in private repositories.


### PR DESCRIPTION
This tool can send a relatively large number of API requests. If not authenticated, the tool may not be able to complete even a single run. Add information about why this happens, and give the user information about how to generate the token.

I work for a soon-to-be enterprise client and needed to run this tool to help determine how many seats we need to license. Including this information in the README would have saved me some time.