### PR TITLE
Add @jonico's audit log api graphql example

### DIFF
--- a/graphql/queries/audit-log-api-example.graphql
+++ b/graphql/queries/audit-log-api-example.graphql
@@ -1,0 +1,51 @@
+# In order for this to work, you need to add a Header: "Accept" : "application/vnd.github.audit-log-preview+json"
+# When querying an enterprise instance via GraphQL, the endpoint will follow the syntax: “https://<HOST>/api/graphql" - ex;"GRAPHQL_ENDPOINT": “https://34.208.232.154/api/graphql"
+
+query {
+  organization(login: "se-saml") {
+    auditLog(first: 50) {
+      edges {
+        node {
+          ... on RepositoryAuditEntryData {
+            repository {
+              name
+            }
+          }
+          ... on OrganizationAuditEntryData {
+            organization {
+              name
+            }
+          }
+
+          ... on TeamAuditEntryData {
+            teamName
+          }
+
+          ... on BusinessAuditEntryData {
+            businessUrl
+          }
+
+          ... on OauthApplicationAuditEntryData {
+            oauthApplicationName
+          }
+
+          ... on AuditEntry {
+            actorResourcePath
+            action
+            actorIp
+            actorLogin
+            createdAt
+            actorLocation {
+              countryCode
+              country
+              regionCode
+              region
+              city
+            }
+          }
+        }
+        cursor
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds an example of querying the audit log via GraphQL, originally in [this gist](https://gist.github.com/jonico/abf33f4bf642bdceca197b9e0ee1de15). 

cc @jonico for review and merge 👀 
