### PR TITLE
Add query to list member email and logins for an Enterprise

### DIFF
--- a/graphql/queries/enterprise-sso-member-details.graphql
+++ b/graphql/queries/enterprise-sso-member-details.graphql
@@ -1,0 +1,28 @@
+# This query will print a list of all SSO members for a Unified Identity Enterprise
+ 
+query listSSOUserIdentities ($enterpriseName:String!) {
+  enterprise(slug: $enterpriseName) {
+    ownerInfo {
+      samlIdentityProvider {
+        externalIdentities(first: 100) {
+          totalCount
+          edges {
+            node {
+              guid
+              samlIdentity {
+                nameId
+              }
+              user {
+                login
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+	          endCursor
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/queries/enterprise-sso-member-details.graphql
+++ b/graphql/queries/enterprise-sso-member-details.graphql
@@ -19,7 +19,7 @@ query listSSOUserIdentities ($enterpriseName:String!) {
           }
           pageInfo {
             hasNextPage
-	          endCursor
+	    endCursor
           }
         }
       }


### PR DESCRIPTION
When an organization has SSO setup through their unified identity enterprise, this query will list all members that have logged in through their idP including their login and email.