### PR TITLE
Add checkpoint feature to find_inactive_members.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 access_token
+api/ruby/find-inactive-members/data
 .DS_Store
 .bundle

--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -49,3 +49,25 @@ Members are defined as inactive if they haven't, since the specified **DATE**,  
 * Have not merged or pushed commits into the default branch
 * Have not opened an Issue or Pull Request
 * Have not commented on an Issue or Pull Request
+
+## Checkpoint
+
+The script sometimes breaks while parsing large organization either caused by timeout or connection error.
+To deal with that frustration, `checkpoint` flag helps by storing Octokit API responses as json files in `data/`, so that during re-run it will first try to use stored json files instead of calling Github API from the beginning.
+
+```
+ruby find_inactive_members.rb [-cehv] -o ORGANIZATION -d DATE --checkpoint
+```
+
+Or simply do this (since it is idempotent)
+
+```
+while true; do ruby find_inactive_members.rb -o ORGANIZATION -d DATE --checkpoint; sleep 10; done
+```
+
+To reset the checkpoint files, simply
+
+```
+rm -rf data/*.json
+rm -rf data/activities/*.json
+```

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -134,18 +134,16 @@ private
       file_name = "data/activities/" + sanitize_filename(repo) + "-commits_since.json"
       commits_since = load_file(file_name, :symbolize_names => true)
       if commits_since == nil
-        commits_since = @client.commits_since(repo, @date)
-        save_file(file_name, commits_since.map(&:to_h))
-      else
-        commits_since = commits_since.map(&:to_h)
+        commits_since = @client.commits_since(repo, @date).map(&:to_h)
+        save_file(file_name, commits_since)
       end
       commits_since.each do |commit|
         # if commmitter is a member of the org and not active, make active
-        if commit["author"].nil?
+        if commit[:author].nil?
           add_unrecognized_author(commit[:commit][:author])
           next
         end
-        if t = @members.find {|member| member[:login] == commit["author"]["login"] && member[:active] == false }
+        if t = @members.find {|member| member[:login] == commit[:author][:login] && member[:active] == false }
           make_active(t[:login])
         end
       end
@@ -163,16 +161,16 @@ private
     file_name = "data/activities/" + sanitize_filename(repo) + "-list_issues.json"
     list_issues = load_file(file_name, :symbolize_names => true)
     if list_issues == nil
-      list_issues = @client.list_issues(repo, { :since => date })
-      save_file(file_name, list_issues.map(&:to_h))
+      list_issues = @client.list_issues(repo, { :since => date }).map(&:to_h)
+      save_file(file_name, list_issues)
     end
     list_issues.each do |issue|
       # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
-      if issue["user"].nil?
+      if issue[:user].nil?
         next
       end
       # if creator is a member of the org and not active, make active
-      if t = @members.find {|member| member[:login] == issue["user"]["login"] && member[:active] == false }
+      if t = @members.find {|member| member[:login] == issue[:user][:login] && member[:active] == false }
         make_active(t[:login])
       end
     end
@@ -184,16 +182,16 @@ private
     file_name = "data/activities/" + sanitize_filename(repo) + "-issues_comments.json"
     issues_comments = load_file(file_name, :symbolize_names => true)
     if issues_comments == nil
-      issues_comments = @client.issues_comments(repo, { :since => date })
-      save_file(file_name, issues_comments.map(&:to_h))
+      issues_comments = @client.issues_comments(repo, { :since => date }).map(&:to_h)
+      save_file(file_name, issues_comments)
     end
     issues_comments.each do |comment|
       # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
-      if comment["user"].nil?
+      if comment[:user].nil?
         next
       end
       # if commenter is a member of the org and not active, make active
-      if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
+      if t = @members.find {|member| member[:login] == comment[:user][:login] && member[:active] == false }
         make_active(t[:login])
       end
     end
@@ -205,16 +203,16 @@ private
     file_name = "data/activities/" + sanitize_filename(repo) + "-pull_requests_comments.json"
     pull_requests_comments = load_file(file_name, :symbolize_names => true)
     if pull_requests_comments == nil
-      pull_requests_comments = @client.pull_requests_comments(repo, { :since => date })
-      save_file(file_name, pull_requests_comments.map(&:to_h))
+      pull_requests_comments = @client.pull_requests_comments(repo, { :since => date }).map(&:to_h)
+      save_file(file_name, pull_requests_comments)
     end
     pull_requests_comments.each do |comment|
       # if there's no user (ghost user?) then skip this   // THIS NEEDS BETTER VALIDATION
-      if comment["user"].nil?
+      if comment[:user].nil?
         next
       end
       # if commenter is a member of the org and not active, make active
-      if t = @members.find {|member| member[:login] == comment["user"]["login"] && member[:active] == false }
+      if t = @members.find {|member| member[:login] == comment[:user][:login] && member[:active] == false }
         make_active(t[:login])
       end
     end

--- a/api/ruby/find-inactive-members/find_inactive_members.rb
+++ b/api/ruby/find-inactive-members/find_inactive_members.rb
@@ -98,7 +98,7 @@ private
         active: false
       }
     end
-    
+
     info "#{@members.length} members found.\n"
   end
 
@@ -286,12 +286,12 @@ private
     # if there is no following period that is followed by something
     # other than a period (yeah, confusing, I know)
     fn = filename.split /(?<=.)\.(?=[^.])(?!.*\.[^.])/m
-  
+
     # We now have one or two parts (depending on whether we could find
     # a suitable period). For each of these parts, replace any unwanted
     # sequence of characters with an underscore
     fn.map! { |s| s.gsub /[^a-z0-9\-]+/i, '_' }
-  
+
     # Finally, join the parts with a period and return the result
     return fn.join '.'
   end


### PR DESCRIPTION
Script `find_inactive_members.rb` sometimes breaks while parsing large organization either caused by timeout or connection error.
Checkpoint  flag `--checkpoint` helps by storing Octokit API responses as json files in `data/`, so that during re-run it will first try to use stored json files instead of calling Github API from the beginning.