### PR TITLE
GraphQL query showing members with linked SCIM identity

### DIFF
--- a/graphql/queries/12-members-with-scim-identity-org.graphql
+++ b/graphql/queries/12-members-with-scim-identity-org.graphql
@@ -1,0 +1,24 @@
+query ($organization: String!) {
+  organization(login: $organization) {
+    samlIdentityProvider {
+      ssoUrl
+      externalIdentities(first: 100) {
+        edges {
+          node {
+            user {
+              login
+              email
+            }
+            scimIdentity {
+              username
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+variables {
+  "organization": "github"
+}

--- a/graphql/queries/13-members-with-scim-identity-enterprise.graphql
+++ b/graphql/queries/13-members-with-scim-identity-enterprise.graphql
@@ -1,0 +1,28 @@
+query ($enterprise: String!) {
+  enterprise(slug: $enterprise) {
+    organizations(first: 100) {
+      nodes {
+        samlIdentityProvider {
+          ssoUrl
+          externalIdentities(first: 100) {
+            edges {
+              node {
+                user {
+                  login
+                  email
+                }
+                scimIdentity {
+                  username
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+variables {
+  "enterprise": "enterprise"
+}


### PR DESCRIPTION
Last month a couple of times people reached out to me and GitHub to ask how to tie organization members to their SCIM identity using our API. 

Previously I shared [a gist](https://gist.github.com/SvanBoxel/06f541b25aab31b7ce19c0f60bcbee4f), but this repository is a better place for these things. 😄 

