### PR TITLE
Fix path in code snippet example

### DIFF
--- a/api/ruby/find-inactive-members/README.md
+++ b/api/ruby/find-inactive-members/README.md
@@ -18,7 +18,7 @@ This utility finds users inactive since a configured date, writes those users to
 
 ```shell
 git clone https://github.com/github/platform-samples.git
-cd api/ruby/find-inactive-members
+cd platform-samples/api/ruby/find-inactive-members
 ```
 
 ### Install dependencies


### PR DESCRIPTION
fix path typo from 
```
cd api/ruby/find-inactive-members
```
to
```
cd platform-samples/api/ruby/find-inactive-members
```