### PR TITLE
changed git-purge-path to git-purge-files in help

### DIFF
--- a/scripts/git-purge-files
+++ b/scripts/git-purge-files
@@ -62,15 +62,15 @@ OPTIONS
 EXAMPLES
        o   Remove the file "test.bin" from all directories:
 
-               \$ git-purge-path "/test.bin$"
+               \$ git-purge-files "/test.bin$"
 
        o   Remove all "*.bin" files from all directories:
 
-               \$ git-purge-path "\.bin$"
+               \$ git-purge-files "\.bin$"
 
        o   Remove all files in the "/foo" directory:
 
-               \$ git-purge-path "^/foo/$"
+               \$ git-purge-files "^/foo/$"
 END
     exit(1);
 }


### PR DESCRIPTION
👋 @larsxschneider I noticed the that help output for `git-purge-files` refers to the command as `git-purge-path` just updated the help output to match the script name