### PR TITLE
GraphQL query for Users in an Organization with SSO enabled

### DIFF
--- a/graphql/queries/users-in-org-with-sso.graphql
+++ b/graphql/queries/users-in-org-with-sso.graphql
@@ -1,0 +1,24 @@
+query listSSOUserIdentities ($organizationName:String!) {
+  organization(login: $organizationName) {
+      samlIdentityProvider {
+        externalIdentities(first: 100) {
+          totalCount
+          edges {
+            node {
+              guid
+              samlIdentity {
+                nameId
+              }
+              user {
+                login
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+	          endCursor
+          }
+        }
+      }
+  }
+}


### PR DESCRIPTION
Graphql query Returns members of an organization and their associated saml identity. If no saml identity, returns null.