### PR TITLE
Fix GraphQL link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ But here it is, broken down:
 * _api_: here's a bunch of sample code relating to the API. Subdirectories in this
 category are broken up by language. Do you have a language sample you'd like added?
 Make a pull request and we'll consider it.
-* _graphql_: here's a bunch of sample GraphQL queries that can be run against our [GitHub GraphQL API](https://developer.github.com/early-access/graphql).
+* _graphql_: here's a bunch of sample GraphQL queries that can be run against our [GitHub GraphQL API](https://developer.github.com/v4/).
 * _hooks_: want to find out how to write a consumer for [our web hooks](https://developer.github.com/webhooks/)? The examples in this subdirectory show you how. We are open for more contributions via pull requests.
 * _pre-receive-hooks_: this one contains [pre-receive-hooks](https://help.github.com/enterprise/admin/guides/developer-workflow/about-pre-receive-hooks/) that can block commits on GitHub Enterprise that do not fit your requirements. Do you have more great examples? Create a pull request and we will check it out.
 * _scripts_: want to analyze or clean-up your Git repository? The scripts in this subdirectory show you how. We are open for more contributions via pull requests.


### PR DESCRIPTION
Update the link to the graphQL API from early access to the v4 url fixing the link