### PR TITLE
added input check and usage to `git-find-large-files` 

### DIFF
--- a/scripts/git-find-large-files
+++ b/scripts/git-find-large-files
@@ -23,7 +23,7 @@ if [ -z "$1" ]; then
     MIN_SIZE_IN_KB=500
 elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
     echo "Error: Expecting Integer Value" >&2
-    echo " Usage: $0 [MIN_SIZE_IN_KB]"
+    echo "Usage: $0 [MIN_SIZE_IN_KB]"
     exit 1
 else
     MIN_SIZE_IN_KB=$1

--- a/scripts/git-find-large-files
+++ b/scripts/git-find-large-files
@@ -21,6 +21,10 @@
 
 if [ -z "$1" ]; then
     MIN_SIZE_IN_KB=500
+elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Error: Expecting Integer Value" >&2; 
+    echo " Usage: $0 [MIN_SIZE_IN_KB]"
+    exit 1
 else
     MIN_SIZE_IN_KB=$1
 fi

--- a/scripts/git-find-large-files
+++ b/scripts/git-find-large-files
@@ -22,7 +22,7 @@
 if [ -z "$1" ]; then
     MIN_SIZE_IN_KB=500
 elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
-    echo "Error: Expecting Integer Value" >&2; 
+    echo "Error: Expecting Integer Value" >&2
     echo " Usage: $0 [MIN_SIZE_IN_KB]"
     exit 1
 else


### PR DESCRIPTION
I ran the `git-find-large-files` command with a `-h` 😁 and ended up with ...

```
./git-find-large-files: line 67: [: -h: integer expression expected
./git-find-large-files: line 67: [: -h: integer expression expected
./git-find-large-files: line 67: [: -h: integer expression expected
...
```

The added check also prevents negative integers.