### PR TITLE
Add script for creating teams in bulk in github orgs

### DIFF
--- a/api/bash/create-teams.sh
+++ b/api/bash/create-teams.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Replace the "xxxxx" with the required values
+# Author: @ppremk
+
+# Script to create GitHub Teams in bulk on GitHub.com Organization
+# PAT Tokens needs to have the correct scope to be able to create teams in an organization
+# Teams are added as an Array. Teams are created as stand alone teams. Team relationship is not defined
+
+# To run the script:
+#
+# - Update VARS section in script
+# - chmod +x script.sh
+# - ./script.sh
+
+# VARS
+ORGNAME="xxxx" 
+PATTOKEN="xxxx"
+TEAMS=("team-name-1" "team-name-2")
+
+echo "Bulk creating teams in:"
+echo $ORGNAME
+
+for i in "${TEAMS[@]}"
+do
+curl --request POST \
+  --url "https://api.github.com/orgs/$ORGNAME/teams" \
+  --header "accept: application/vnd.github.v3+json" \
+  --header "authorization: Bearer ${PATTOKEN}" \
+  --header "content-type: application/json" \
+  --data "{\"name\": \"$i\", \"privacy\": \"closed\" }"
+done
+
+if [ $ERROR_CODE -ne 0 ]; then
+  echo "Team creation failed! Please verify validity of supplied configurations."
+  exit 1
+else
+  echo "Teams succesfully created!"
+fi
+
+

--- a/api/bash/create-teams.sh
+++ b/api/bash/create-teams.sh
@@ -13,28 +13,31 @@
 # - ./script.sh
 
 # VARS
-ORGNAME="xxxx" 
-PATTOKEN="xxxx"
-TEAMS=("team-name-1" "team-name-2")
+orgname="xxx" 
+pattoken="xxxxxxx"
+teams=("team-name-1" "team-name-2")
 
 echo "Bulk creating teams in:"
-echo $ORGNAME
+echo $orgname
 
-for i in "${TEAMS[@]}"
-do
-curl --request POST \
-  --url "https://api.github.com/orgs/$ORGNAME/teams" \
-  --header "accept: application/vnd.github.v3+json" \
-  --header "authorization: Bearer ${PATTOKEN}" \
-  --header "content-type: application/json" \
-  --data "{\"name\": \"$i\", \"privacy\": \"closed\" }"
+for i in "${teams[@]}"
+  do
+    curl --request POST \
+      --url "https://api.github.com/orgs/$orgname/teams" \
+      --header "accept: application/vnd.github.v3+json" \
+      --header "authorization: Bearer ${pattoken}" \
+      --header "content-type: application/json" \
+      --data "{\"name\": \"$i\", \"privacy\": \"closed\" }" \
+      -- fail
+
+    retVal=$?
+    if [ $retVal -ne 0 ]; then
+      echo "Team creation failed! Please verify validity of supplied configurations."
+      exit 1
+    fi  
 done
+echo "Teams succesfully created!"
 
-if [ $ERROR_CODE -ne 0 ]; then
-  echo "Team creation failed! Please verify validity of supplied configurations."
-  exit 1
-else
-  echo "Teams succesfully created!"
-fi
+
 
 


### PR DESCRIPTION
This PR adds a bash script to create teams in bulk to help Org owners to get up and running when setting up teams as part of their migration effort.