### PR TITLE
Changing BusinesAuditEntryData to Enterprise

### DIFF
--- a/graphql/queries/org-audit-log-api-example.graphql
+++ b/graphql/queries/org-audit-log-api-example.graphql
@@ -21,8 +21,8 @@ query {
             teamName
           }
 
-          ... on BusinessAuditEntryData {
-            businessUrl
+          ... on EnterpriseAuditEntryData {
+            enterpriseUrl
           }
 
           ... on OauthApplicationAuditEntryData {


### PR DESCRIPTION
This pull request changes the reference to the `BusinessAuditEntryData` interface in the audit log example query to the `EnterpriseAuditEntryData` interface, as this reflects the renaming of the interface on the GitHub GraphQL API

https://docs.github.com/en/graphql/reference/interfaces#enterpriseauditentrydata

The change includes an update to the `businessUrl` field to the `enterpriseUrl` field, as that field has been renamed on the interface as well.

Relevant changelog entry https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2019-07-17