### PR TITLE
Add SQL queries for GitHub Enterprise Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Make a pull request and we'll consider it.
 * _hooks_: want to find out how to write a consumer for [our web hooks](https://developer.github.com/webhooks/)? The examples in this subdirectory show you how. We are open for more contributions via pull requests.
 * _pre-receive-hooks_: this one contains [pre-receive-hooks](https://help.github.com/enterprise/admin/guides/developer-workflow/about-pre-receive-hooks/) that can block commits on GitHub Enterprise that do not fit your requirements. Do you have more great examples? Create a pull request and we will check it out.
 * _scripts_: want to analyze or clean-up your Git repository? The scripts in this subdirectory show you how. We are open for more contributions via pull requests
+* _sql_: here are sql scripts for custom reporting for GitHub Enterprise Server. We are open for more contributions via pull requests.

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,0 +1,25 @@
+# SQL Queries for GitHub Enterprise Server
+
+:warning: Run these directly against your GitHub Enterprise Server database at your own risk.  A safer method to run these is outlined [here](USAGE.md).
+
+## Audit queries
+
+The `audit` folder has queries that are all around auditing credentials, webhooks, apps, etc.
+
+- `admin-tokens.sql` - A report of all tokens with the `site_admin` scope and when they were last used.
+- `authorizations.sql` - A report of all personal access tokens and when they were last used.  Same as above, but without the `site_admin` scope limitation.  This is a big report.
+- `deploy-keys.sql` - A report of all deploy keys, when it was last used, who set it up and when, how long the key is, and what repository it's tied to.
+- `github-apps.sql` - A report of all GitHub apps, who owns them, the scope it's installed at, if it's public or not, and the URL it's sending data to.
+- `hooks-repos.sql` - A report of all repository webhooks used in the past week, who owns it, and where the webhook goes.  This is limited to a week based on the length of time these are kept in the `hookshot_delivery_logs` table.
+- `hooks-users.sql` - Same report as above, but for user-owned webhooks.
+- `oauth-apps.sql` - A report of all OAuth apps, who owns it, where it goes, and when it was last used.
+- `user-emails.sql` - A report of all emails that don't match a list of approved domains you define in the `WHERE` clause.  This query should be deprecated by [this issue](https://github.com/github/roadmap/issues/204).
+- `user-ssh-keys.sql` - A report of all user SSH keys, when it was last used, when it was set up, and how long the key is.
+
+## Security queries
+
+The `security` folder has queries that are all around dependency alerts and any other security features.
+
+## Usage queries
+
+The `usage` folder has queries that are all around usage of various features in GitHub Enterprise Server.

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,6 +1,8 @@
 # SQL Queries for GitHub Enterprise Server
 
-:warning: Run these directly against your GitHub Enterprise Server database at your own risk.  A safer method to run these is outlined [here](USAGE.md).
+:warning: While these are all read-only queries and do not write to the database, run these directly against your GitHub Enterprise Server database at your own risk.  A safer method to run these is outlined [here](USAGE.md).
+
+Each query has a comment at the top of the file elaborating what it does, etc.
 
 ## Audit queries
 
@@ -19,6 +21,10 @@ The `audit` folder has queries that are all around auditing credentials, webhook
 ## Security queries
 
 The `security` folder has queries that are all around dependency alerts and any other security features.
+
+- `active-repo-report.sql` - A list of all detected HIGH and CRITICAL vulnerabilities from repos pushed to in the past 90 days.  It also returns who owns it and further details on the exact vulnerability.  The threshold of time and severity to return is adjustable.
+- `vuln-critical-count.sql` - A count of repositories affected by each CRITICAL vulnerability.
+- `vuln-report.sql` - A report of all detected vulnerabilities in every single repo in GHES, who owns it, when it was last pushed to, the platform of the vulnerability, and the GHSA/MITRE/WhiteSource info on it.  This can be a very large report.
 
 ## Usage queries
 

--- a/sql/README.md
+++ b/sql/README.md
@@ -24,6 +24,7 @@ The `metrics` folder has queries that are all around usage of various features i
 
 - `actions-summary.sql` - A monthly summary of runtime hours, seconds waiting in queue before dispatch, and job count for GitHub Actions usage.
 - `commit-count.sql` - This pulls a "high score" report of all users, all commits, from all time.
+- `commit-summary.sql` - A month-by-month summary of commits pushed to GitHub Enterprise Server (using the commit date).
 - `count-tabs.sql` - A report of the custom tabs users put in their repositories.
 - `issue-report.sql` - A report of active issues within the past X days.
 - `linguist-report.sql` - This returns the "size" of each language in each repository and when the repo was last updated.  This can be a very large report.

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,24 @@ The `audit` folder has queries that are all around auditing credentials, webhook
 - `user-emails.sql` - A report of all emails that don't match a list of approved domains you define in the `WHERE` clause.  This query should be deprecated by [this issue](https://github.com/github/roadmap/issues/204).
 - `user-ssh-keys.sql` - A report of all user SSH keys, when it was last used, when it was set up, and how long the key is.
 
+## Metrics queries
+
+The `metrics` folder has queries that are all around usage of various features in GitHub Enterprise Server.
+
+- `actions-summary.sql` - A monthly summary of runtime hours, seconds waiting in queue before dispatch, and job count for GitHub Actions usage.
+- `commit-count.sql` - This pulls a "high score" report of all users, all commits, from all time.
+- `count-tabs.sql` - A report of the custom tabs users put in their repositories.
+- `issue-report.sql` - A report of active issues within the past X days.
+- `linguist-report.sql` - This returns the "size" of each language in each repository and when the repo was last updated.  This can be a very large report.
+- `linguist-stats.sql` - This returns the count of repositories containing each language and a sum "size" of code in that language for all repos pushed to in the past year.  The time limit is adjustable.
+- `most-recent-active-repos.sql` - A list of repositories, when they were last updated, who owns them, and the disk space associated with each.
+- `pr-report.sql` - This pulls a report of pull requests including the repo name, user name, files included, times it was created/updated/merged, and comments.  It can filter by organization or return all PRs in GHES.
+- `prereceive-hooks.sql` - A list of pre-receive hooks that are enabled by each repository and who owns the repo.
+- `public-repo-owners.sql` - A list of all users or orgs who own repositories marked as "public", a count of public repos, and the user or org email address.
+- `reaction-stats.sql` - A count of the reactions used in GHES for trivia.
+- `staff-notes.sql` - Returns a list of organizations or users with `staff_notes`.
+- `user-report.sql` - Returns username, id, created/suspended date, issues created for all time and in the past 30 days, number of repos owned, and how many pull requests they've opened.
+
 ## Security queries
 
 The `security` folder has queries that are all around dependency alerts and any other security features.
@@ -25,7 +43,3 @@ The `security` folder has queries that are all around dependency alerts and any 
 - `active-repo-report.sql` - A list of all detected HIGH and CRITICAL vulnerabilities from repos pushed to in the past 90 days.  It also returns who owns it and further details on the exact vulnerability.  The threshold of time and severity to return is adjustable.
 - `vuln-critical-count.sql` - A count of repositories affected by each CRITICAL vulnerability.
 - `vuln-report.sql` - A report of all detected vulnerabilities in every single repo in GHES, who owns it, when it was last pushed to, the platform of the vulnerability, and the GHSA/MITRE/WhiteSource info on it.  This can be a very large report.
-
-## Usage queries
-
-The `usage` folder has queries that are all around usage of various features in GitHub Enterprise Server.

--- a/sql/USAGE.md
+++ b/sql/USAGE.md
@@ -1,1 +1,49 @@
 # Using the SQL queries
+
+The safest way to run these queries is by using the backup created by [backup-utils](https://github.com/github/backup-utils) loaded into another database server.  This database can be quite large and GitHub Enterprise Server can be sensitive to I/O intensive operations that aren't part of anticipated load.
+
+:warning:  This database contains sensitive information.  Please treat it appropriately within your company / network!
+
+A simple way to do this would be to install a MySQL 5.7 server on the VM receiving the backups and load it automatically.  You can then connect to in using `root` with no password, or whatever you set up for authentication.  What this looks like in practice would be similar to this shell script:
+
+```shell
+# Stop MySQL
+sudo systemctl stop mysqld.service
+
+# Unzip the most current backup
+gunzip -c /data/current/mysql.sql.gz > /data/mysql.tar
+
+# Untar the current backup
+tar xf /data/mysql.tar --directory=/home/github/restore-job/
+
+# Remove the temporary tarball
+rm /data/mysql.tar
+
+# Clear the data directory before restoring
+sudo rm -rf /var/lib/mysql-data/*
+
+# Run the Percona backup restore
+cd /home/github/restore-job && sudo innobackupex --defaults-file=backup-my.cnf --copy-back --datadir=/var/lib/mysql-data .
+
+# Restore the innodb buffer pool
+sudo cp -n /var/lib/mysql/ib_buffer_pool /var/lib/mysql-data/
+
+# Restore the innodb data
+sudo cp -n /var/lib/mysql/ibdata1 /var/lib/mysql-data/
+
+# Restore the first and second logs
+sudo cp -n /var/lib/mysql/ib_logfile0 /var/lib/mysql-data/
+sudo cp -n /var/lib/mysql/ib_logfile1 /var/lib/mysql-data/
+
+# Reset ownership
+sudo chown -R mysql:mysql /var/lib/mysql-data
+
+# Restore SELinux contexts (if applicable)
+sudo restorecon -R /var/lib/mysql-data
+
+# Start MySQL
+sudo systemctl start mysqld.service
+
+# Clear the working directory to save some disk space
+rm -rf /home/github/restore-job/*
+```

--- a/sql/USAGE.md
+++ b/sql/USAGE.md
@@ -1,0 +1,1 @@
+# Using the SQL queries

--- a/sql/audit/admin-tokens.sql
+++ b/sql/audit/admin-tokens.sql
@@ -1,0 +1,23 @@
+/*
+ * This pulls a list of all apps, tokens, and scopes associated with that token
+ * as well as when it was last used, created, and updated for anything with 
+ * the `site_admin` scope.
+ */
+SELECT
+	z.id,
+	u.login as owner_name,
+	u.type as owner_type,
+	a.name as app_name,
+	z.accessed_at,
+	z.created_at,
+	z.updated_at,
+	z.description,
+	z.scopes
+FROM
+	github_enterprise.oauth_authorizations z
+JOIN github_enterprise.users u ON
+	z.user_id = u.id
+LEFT JOIN github_enterprise.oauth_applications a ON
+	z.application_id = a.id
+WHERE
+	z.scopes LIKE "%site_admin%"

--- a/sql/audit/authorizations.sql
+++ b/sql/audit/authorizations.sql
@@ -1,0 +1,20 @@
+/* 
+ * This pulls a list of all apps, tokens, and scopes associated with that token
+ * as well as when it was last used, created, and updated.
+ */
+SELECT
+	z.id,
+	u.login as owner_name,
+	u.type as owner_type,
+	a.name as app_name,
+	z.accessed_at,
+	z.created_at,
+	z.updated_at,
+	z.description,
+	z.scopes
+FROM
+	github_enterprise.oauth_authorizations z
+JOIN github_enterprise.users u ON
+	z.user_id = u.id
+LEFT JOIN github_enterprise.oauth_applications a ON
+	z.application_id = a.id;

--- a/sql/audit/deploy-keys.sql
+++ b/sql/audit/deploy-keys.sql
@@ -1,0 +1,32 @@
+/* 
+ * This query returns SSH deploy keys and what repo they're tied to, when last
+ * used, etc.
+ */
+SELECT
+	d.title as key_name,
+	d.created_at,
+	d.updated_at,
+	d.verified_at,
+	d.accessed_at as last_used,
+	length(d.key) as key_length,
+	u.login as created_by_name,
+	d.created_by as created_by_type,
+	r.name as repo_name,
+	x.login as repo_owner_name
+FROM
+	github_enterprise.public_keys d
+LEFT JOIN github_enterprise.users u ON
+	d.creator_id = u.id
+LEFT JOIN github_enterprise.repositories r ON
+	d.repository_id = r.id
+LEFT JOIN (
+	SELECT
+		id,
+		login,
+		type
+	FROM
+		github_enterprise.users u2
+    ) x ON
+	x.id = r.owner_id
+WHERE
+	d.repository_id IS NOT NULL;

--- a/sql/audit/github-apps.sql
+++ b/sql/audit/github-apps.sql
@@ -1,0 +1,20 @@
+/* 
+ * This pulls a list of all github apps, who owns them, and when they were 
+ * created or updated.
+ */
+SELECT
+	i.id,
+	i.bot_id,
+	i.name as integration_name,
+	u.login as owner,
+	u.type,
+	i.url,
+	i.created_at,
+	i.updated_at,
+	i.public,
+	i.slug as friendly_name,
+	i.public
+FROM
+	github_enterprise.integrations i
+JOIN github_enterprise.users u ON
+	i.owner_id = u.id;

--- a/sql/audit/hooks-repos.sql
+++ b/sql/audit/hooks-repos.sql
@@ -1,0 +1,30 @@
+/* 
+ * This brings up the list of REPOSITORY webhooks that have been active in the
+ * past week, who owns them, and where the webhook goes.
+ */
+SELECT
+	DISTINCT h.id,
+	u.login as creator,
+	h.updated_at,
+	r.name as repo_name,
+	u.login as repo_owner,
+	u.type as owner_type,
+	c.value as url,
+	MAX(l.delivered_at) as latest_delivery
+FROM
+	github_enterprise.hooks h
+JOIN github_enterprise.hook_config_attributes c ON
+	h.id = c.hook_id
+JOIN github_enterprise.users u ON
+	h.creator_id = u.id
+JOIN github_enterprise.hookshot_delivery_logs l ON
+	h.id = l.hook_id
+JOIN github_enterprise.repositories r ON
+	h.installation_target_id = r.id
+WHERE
+	c.key = 'url'
+	AND h.installation_target_type = 'Repository'
+GROUP BY
+	h.id
+ORDER BY
+	MAX(l.delivered_at) DESC;

--- a/sql/audit/hooks-users.sql
+++ b/sql/audit/hooks-users.sql
@@ -1,0 +1,27 @@
+/*
+ * This brings up the list of USER webhooks that have been active in the past
+ * week, who owns them, and where the webhook goes.
+ */
+SELECT
+	DISTINCT h.id,
+	u.login as creator,
+	h.updated_at,
+	u.login as repo_owner,
+	u.type as owner_type,
+	c.value as url,
+	MAX(l.delivered_at) as latest_delivery
+FROM
+	github_enterprise.hooks h
+JOIN github_enterprise.hook_config_attributes c ON
+	h.id = c.hook_id
+JOIN github_enterprise.users u ON
+	h.creator_id = u.id
+JOIN github_enterprise.hookshot_delivery_logs l ON
+	h.id = l.hook_id
+WHERE
+	c.key = 'url'
+	AND h.installation_target_type = 'User'
+GROUP BY
+	h.id
+ORDER BY
+	MAX(l.delivered_at) DESC;

--- a/sql/audit/oauth-apps.sql
+++ b/sql/audit/oauth-apps.sql
@@ -1,0 +1,16 @@
+/*
+ * This pulls up a list of all OAuth apps and where they go, as well as when
+ * they were last updated and what login they are associated with.
+ */
+SELECT
+	o.name,
+	o.url,
+	o.callback_url,
+	o.created_at,
+	o.updated_at,
+	u.login,
+	u.type
+FROM
+	github_enterprise.oauth_applications o
+JOIN github_enterprise.users u ON
+	o.user_id = u.id;

--- a/sql/audit/user-emails.sql
+++ b/sql/audit/user-emails.sql
@@ -1,0 +1,22 @@
+/* 
+ * This pulls a list of all email addresses and the user account it is tied to
+ * that don't match the list of domains in the WHERE clause.  Add however many
+ * "%domain.com" needed to cover your company's approved domains.
+ *
+ * This query should be deprecated by this issue:
+ * https://github.com/github/roadmap/issues/204
+ *
+ * If you want a list of all emails, remove the WHERE clause.
+ */
+SELECT
+	u.login,
+	e.email,
+	u.suspended_at
+FROM
+	github_enterprise.users u
+JOIN github_enterprise.user_emails e ON
+	e.user_id = u.id
+WHERE
+	u.gravatar_email != e.email
+	AND e.email not like "%company.com"
+	AND e.email not like "%.tld";

--- a/sql/audit/user-ssh-keys.sql
+++ b/sql/audit/user-ssh-keys.sql
@@ -1,0 +1,18 @@
+/*
+ * This query returns user SSH keys and when they were last used.
+ */
+SELECT
+	d.title as key_name,
+	d.created_at,
+	d.updated_at,
+	d.verified_at,
+	d.accessed_at as last_used,
+	length(d.key) as key_length,
+	u.login as created_by_name,
+	d.created_by as created_by_type
+FROM
+	github_enterprise.public_keys d
+LEFT JOIN github_enterprise.users u ON
+	d.creator_id = u.id
+WHERE
+	d.user_id IS NOT NULL;

--- a/sql/metrics/actions-summary.sql
+++ b/sql/metrics/actions-summary.sql
@@ -1,0 +1,28 @@
+/* 
+ * This query generates a monthly summary of runtime hours, seconds waiting 
+ * in queue before dispatch, and job count for GitHub Actions usage.
+ */
+SELECT
+	month(j.completed_at) as month,
+	year(j.completed_at) as year,
+	round(
+		sum(
+			unix_timestamp(j.completed_at) - unix_timestamp(
+				coalesce(j.started_at, j.queued_at, j.created_at)
+			)
+		) / 3600
+	) as compute_hours,
+	round(
+		avg(
+			unix_timestamp(j.started_at) - unix_timestamp(j.queued_at)
+		)
+	) as seconds_queued,
+	count(j.completed_at) as job_count
+FROM
+	github_enterprise.workflow_builds j
+GROUP BY
+	month,
+	year
+ORDER BY
+	year,
+	month

--- a/sql/metrics/commit-count.sql
+++ b/sql/metrics/commit-count.sql
@@ -1,0 +1,14 @@
+/* 
+ * This pulls a "high score" report of all users, all commits, from all time.
+ */
+SELECT
+	u.login,
+	SUM(commit_count)
+FROM
+	github_enterprise.commit_contributions c
+JOIN github_enterprise.users u ON
+	u.id = c.user_id
+GROUP BY
+	user_id
+ORDER BY
+	COUNT(c.user_id) DESC;

--- a/sql/metrics/commit-summary.sql
+++ b/sql/metrics/commit-summary.sql
@@ -1,0 +1,15 @@
+/* 
+ * This query generates a monthly summary of commit activity by committed date.
+ */
+SELECT
+	month(c.committed_date) as month,
+	year(c.committed_date) as year,
+	sum(c.commit_count) as commits
+FROM
+	github_enterprise.commit_contributions c
+GROUP BY
+	month,
+	year
+ORDER BY
+	year,
+	month

--- a/sql/metrics/count-tabs.sql
+++ b/sql/metrics/count-tabs.sql
@@ -1,0 +1,17 @@
+/* 
+ * These are custom tabs set by a repository owner that show up to their users.
+ */
+SELECT
+	t.anchor as name,
+	t.url,
+	t.created_at,
+	t.updated_at,
+	r.name as repo_name,
+	u.login as owner_name,
+	u.type as owner_type
+FROM
+	github_enterprise.tabs t
+JOIN github_enterprise.repositories r ON
+	t.repository_id = r.id
+JOIN github_enterprise.users u ON
+	r.owner_id = u.id;

--- a/sql/metrics/issue-report.sql
+++ b/sql/metrics/issue-report.sql
@@ -1,0 +1,25 @@
+/* 
+ * This query returns a report of active issues within the past X days.
+ */
+SELECT
+	r.name as repo_name,
+	u.login as created_by,
+	v.login as assigned_to,
+	i.state as issue_state,
+	i.created_at,
+	i.updated_at,
+	i.closed_at,
+	i.issue_comments_count,
+	DATEDIFF(i.closed_at, i.created_at) as days_open
+FROM
+	github_enterprise.issues i
+LEFT JOIN github_enterprise.users u ON
+	i.user_id = u.id
+LEFT JOIN github_enterprise.users v ON
+	i.assignee_id = v.id
+INNER JOIN github_enterprise.repositories r ON
+	i.repository_id = r.id
+WHERE
+	DATEDIFF(NOW(), i.created_at) <= 365
+ORDER BY
+	days_open DESC;

--- a/sql/metrics/issue-summary.sql
+++ b/sql/metrics/issue-summary.sql
@@ -1,0 +1,15 @@
+/* 
+ * This query generates a monthly summary of issues created.
+ */
+SELECT
+	month(i.created_at) as month,
+	year(i.created_at) as year,
+	count(i.created_at) as issues
+FROM
+	github_enterprise.issues i
+GROUP BY
+	month,
+	year
+ORDER BY
+	year,
+	month

--- a/sql/metrics/linguist-report.sql
+++ b/sql/metrics/linguist-report.sql
@@ -1,0 +1,16 @@
+/* 
+ * This lists the "size" of each language in each repository and when the repo
+ * was last updated.
+ */
+SELECT
+	r.name,
+	l.updated_at,
+	l.public,
+	l.size,
+	n.name
+FROM
+	github_enterprise.languages l
+JOIN github_enterprise.language_names n ON
+	l.language_name_id = n.id
+JOIN github_enterprise.repositories r ON
+	l.repository_id = r.id;

--- a/sql/metrics/linguist-stats.sql
+++ b/sql/metrics/linguist-stats.sql
@@ -1,0 +1,28 @@
+/*
+ * This pulls the number of repositories containing any individual language
+ * that have been pushed to in the past year.
+ *
+ * If you comment out the WHERE clause, it'll return the stats for your server
+ * for all time.
+ */
+SELECT
+	n.name as language_name,
+	COUNT(l.language_name_id) as repo_count,
+	ROUND(SUM(l.size) /(1024 * 1024)) as language_size_mb
+FROM
+	github_enterprise.languages l
+	JOIN github_enterprise.language_names n ON l.language_name_id = n.id
+	JOIN github_enterprise.repositories r ON l.repository_id = r.id
+WHERE
+	r.id IN (
+		SELECT
+			r.id
+		FROM
+			github_enterprise.repositories r
+		WHERE
+			DATEDIFF(NOW(), r.updated_at) < 365
+	)
+GROUP BY
+	language_name_id
+ORDER BY
+	COUNT(l.language_name_id) DESC;

--- a/sql/metrics/most-recent-active-repos.sql
+++ b/sql/metrics/most-recent-active-repos.sql
@@ -1,0 +1,15 @@
+/* 
+ * This pulls a list of repositories, when they were last updated, who owns 
+ * them, and the disk space associated with each.
+ */
+SELECT
+	r.name as repo_name,
+	r.updated_at,
+	r.disk_usage,
+	u.login
+FROM
+	github_enterprise.repositories r
+JOIN github_enterprise.users u ON
+	r.owner_id = u.id
+ORDER BY
+	updated_at DESC;

--- a/sql/metrics/pr-report.sql
+++ b/sql/metrics/pr-report.sql
@@ -1,0 +1,28 @@
+/* 
+ * This pulls a report of pull requests including the repo name, user name, 
+ * files included, times it was created/updated/merged, and comments.
+ *
+ * If you know the organization ID you're interested in, uncomment and put it
+ * in line 27 to filter this to a specific org.  Otherwise, this query returns
+ * all pull requests in GitHub Enterprise Server.
+ */
+SELECT
+	r.name,
+	u.login,
+	path as filename,
+	p.id as pr_id,
+	p.created_at as created_time,
+	p.updated_at as updated_time,
+	p.merged_at as merged_time,
+	CONVERT(body
+		USING utf8) as comment
+FROM
+	github_enterprise.pull_request_review_comments c
+JOIN github_enterprise.users u ON
+	u.id = c.user_id
+JOIN github_enterprise.pull_requests p ON
+	p.id = c.pull_request_id
+JOIN github_enterprise.repositories r ON
+	r.id = c.repository_id
+-- WHERE r.owner_id = (org id here)
+;

--- a/sql/metrics/prereceive-hooks.sql
+++ b/sql/metrics/prereceive-hooks.sql
@@ -1,0 +1,16 @@
+/* 
+ * This returns a list of pre-receive hooks that are enabled by each repository
+ * and who owns the repo.
+ */
+SELECT
+	h.name as hook_name,
+	r.name as repo_name,
+	u.login as owner_name
+FROM
+	github_enterprise.pre_receive_hook_targets t
+JOIN github_enterprise.pre_receive_hooks h ON
+	h.id = t.hook_id
+JOIN github_enterprise.repositories r ON
+	r.id = t.hookable_id
+JOIN github_enterprise.users u ON
+	r.owner_id = u.id;

--- a/sql/metrics/public-repo-owners.sql
+++ b/sql/metrics/public-repo-owners.sql
@@ -1,0 +1,23 @@
+/*
+ * This query returns a report of the owners of public repositories in GHES,
+ * their user or organization email address, and how many repos they publicly
+ * own.
+ */
+SELECT
+	u.login,
+	e.email,
+	u.organization_billing_email,
+	count(r.owner_id) as repo_count
+FROM
+	github_enterprise.repositories r
+JOIN github_enterprise.users u ON
+	r.owner_id = u.id
+LEFT JOIN github_enterprise.user_emails e ON
+	u.id = e.user_id
+WHERE
+	r.public = 1
+GROUP BY
+	u.login,
+	e.email
+ORDER BY
+	repo_count DESC;

--- a/sql/metrics/reactions-stats.sql
+++ b/sql/metrics/reactions-stats.sql
@@ -1,0 +1,12 @@
+/* 
+ * This query returns a count of all the reactions used in GHES for fun facts.
+ */
+SELECT
+	content,
+	COUNT(content) as count
+FROM
+	github_enterprise.reactions
+GROUP BY
+	content
+ORDER BY
+	COUNT(content) DESC;

--- a/sql/metrics/staff-notes.sql
+++ b/sql/metrics/staff-notes.sql
@@ -1,0 +1,17 @@
+/* 
+ * This query returns a list of organizations or users with staff_notes.
+ *
+ * Optionally, you can search for a specific string in the WHERE clause.
+ */
+SELECT
+	u.login as "User Name",
+	u.type as Type,
+	s.note as Note,
+	s.created_at as "Created At",
+	s.updated_at as "Last Updated"
+FROM
+	github_enterprise.staff_notes s
+JOIN github_enterprise.users u ON
+	s.notable_id = u.id
+-- WHERE
+-- 	s.note LIKE '%string-to-search-for%';

--- a/sql/metrics/user-report.sql
+++ b/sql/metrics/user-report.sql
@@ -1,0 +1,55 @@
+/*
+ * This query returns the username, id, created/suspended date, issues created
+ * for all time and in the past 30 days, number of repos owned, and how many
+ * pull requests they've opened.
+ */
+SELECT
+	u.login,
+	u.id,
+	u.created_at,
+	u.suspended_at,
+	i.cnt issues_created_all_time,
+	i2.cnt issues_created_30_days,
+	r.cnt repos_owned,
+	pr.cnt prs_opened
+FROM
+	github_enterprise.users u
+LEFT JOIN (
+	SELECT
+		user_id,
+		count(id) cnt
+	FROM
+		github_enterprise.issues
+	GROUP BY
+		user_id ) i ON
+	i.user_id = u.id
+LEFT JOIN (
+	SELECT
+		user_id,
+		count(id) cnt
+	FROM
+		github_enterprise.issues
+	WHERE
+		DATEDIFF(NOW(), created_at) <= 30
+	GROUP BY
+		user_id ) i2 ON
+	i2.user_id = u.id
+LEFT JOIN (
+	SELECT
+		owner_id,
+		count(id) cnt
+	FROM
+		github_enterprise.repositories
+	GROUP BY
+		owner_id ) r ON
+	r.owner_id = u.id
+LEFT JOIN (
+	SELECT
+		user_id,
+		count(id) cnt
+	FROM
+		github_enterprise.pull_requests
+	GROUP BY
+		user_id ) pr ON
+	pr.user_id = u.id
+;

--- a/sql/security/active-repo-report.sql
+++ b/sql/security/active-repo-report.sql
@@ -1,0 +1,34 @@
+/*
+ * This pulls a list of all detected HIGH and CRITICAL vulnerabilities from
+ * repositories pushed to in the past 90 days.  It also returns who owns it and
+ * further details on the exact vulnerability.
+ *
+ * If you comment line 34, it will both root and fork repositories.  As is, 
+ * it will only report root repos.
+ */
+SELECT
+	r.name AS repo_name,
+	u.login AS repo_owner,
+	u.type AS owner_type,
+	pushed_at AS last_update,
+	platform,
+	severity,
+	cve_id,
+	ghsa_id,
+	white_source_id,
+	external_reference
+FROM
+	github_enterprise.repository_vulnerability_alerts z
+JOIN github_enterprise.vulnerabilities v ON
+	z.vulnerability_id = v.id
+JOIN github_enterprise.repositories r ON
+	z.repository_id = r.id
+JOIN github_enterprise.users u ON
+	r.owner_id = u.id
+WHERE
+	(v.severity = "critical"
+		OR v.severity = "high")
+	AND DATEDIFF(NOW(), r.pushed_at) < 91
+	AND r.parent_id IS NULL
+ORDER BY
+	last_update DESC;

--- a/sql/security/active-repo-report.sql
+++ b/sql/security/active-repo-report.sql
@@ -3,7 +3,7 @@
  * repositories pushed to in the past 90 days.  It also returns who owns it and
  * further details on the exact vulnerability.
  *
- * If you comment line 34, it will both root and fork repositories.  As is, 
+ * If you comment line 32, it will both root and fork repositories.  As is, 
  * it will only report root repos.
  */
 SELECT

--- a/sql/security/vuln-critical-count.sql
+++ b/sql/security/vuln-critical-count.sql
@@ -1,0 +1,22 @@
+/* 
+ * This pulls a count of repos affected by each _critical_ vulnerability.
+ */
+SELECT
+	v.id,
+	v.cve_id,
+	v.ghsa_id,
+	v.white_source_id,
+	v.published_at as published,
+	v.external_reference,
+	v.platform as ecosystem,
+	COUNT(z.vulnerability_id) as repo_count
+FROM
+	github_enterprise.repository_vulnerability_alerts z
+JOIN github_enterprise.vulnerabilities v ON
+	z.vulnerability_id = v.id
+WHERE
+	v.severity = 'critical'
+GROUP BY
+	v.id
+ORDER BY
+	COUNT(z.vulnerability_id) DESC;

--- a/sql/security/vuln-report.sql
+++ b/sql/security/vuln-report.sql
@@ -1,0 +1,26 @@
+/* 
+ * This pulls a list of all detected vulnerabilities, what it is, who owns the 
+ * associated repo, and when the repo was last updated.  This can be a very
+ * large report!
+ */
+SELECT
+	r.name as repo_name,
+	u.login as repo_owner,
+	u.type as owner_type,
+	pushed_at as last_update,
+	platform,
+	severity,
+	cve_id,
+	ghsa_id,
+	white_source_id,
+	external_reference
+FROM
+	github_enterprise.repository_vulnerability_alerts z
+JOIN github_enterprise.vulnerabilities v ON
+	z.vulnerability_id = v.id
+JOIN github_enterprise.repositories r ON
+	z.repository_id = r.id
+JOIN github_enterprise.users u ON
+	r.owner_id = u.id
+ORDER BY
+	last_update DESC;


### PR DESCRIPTION
This PR contains a lot of SQL scripts, with directions and detailed comments, to run against GitHub Enterprise Server for custom reporting around auditing, security alerts, and general metrics.  These are currently in use at Booz Allen to provide reporting not available via the API.