### PR TITLE
Create example hook to reject web UI blob edits to a specific branch

### DIFF
--- a/pre-receive-hooks/restrict-master-to-cli.sh
+++ b/pre-receive-hooks/restrict-master-to-cli.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This hook restricts changes on the default branch to disallow the Web UI blob editor
+#
+DEFAULT_BRANCH=$(git symbolic-ref HEAD)
+while read -r oldrev newrev refname; do
+  if [[ "${refname}" != "${DEFAULT_BRANCH:=refs/heads/master}" ]]; then
+    continue
+  else
+    if [[ "${GITHUB_VIA}" = 'blob#save' ]]; then
+      echo "Changes to the default branch must be made by cli. Web UI edits are not allowed."
+      exit 1
+    else
+      continue
+    fi
+  fi
+done


### PR DESCRIPTION
Similar / opposite idea as https://github.com/github/platform-samples/blob/master/pre-receive-hooks/restrict-master-to-gui-merges.sh

This prevents edits via the web UI file editor from saving an edit to a specified branch:

![Screenshot 2023-03-17 at 10 00 51 AM](https://user-images.githubusercontent.com/3662109/225970510-9db612bc-b017-48bf-9962-155820666a7a.png)
