### PR TITLE
Added bash script to query an enterprise for app installs.

### DIFF
--- a/api/bash/app-installs.sh
+++ b/api/bash/app-installs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# The first argument passed to the script is assigned to the variable ENTERPRISE
+ENTERPRISE="$1"
+
+# This is a GraphQL query that fetches the first 50 organizations of an enterprise
+# The query takes two variables: slug (the enterprise's slug) and endCursor (for pagination)
+QUERY='
+query($slug:String!, $endCursor:String) {
+  enterprise(slug:$slug){
+    organizations(first:50, after:$endCursor){
+      pageInfo{
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        login
+      }
+    }
+  }
+}'
+
+# This loop iterates over each organization in the enterprise
+# The 'gh api graphql' command is used to execute the GraphQL query
+# The '-f' option is used to pass the query string
+# The '-F' option is used to pass the enterprise's slug
+# The '--jq' option is used to parse the JSON response and extract the login of each organization
+for organization in $(gh api graphql -f query="${QUERY}" -F slug="${ENTERPRISE}" --jq '.data.enterprise.organizations.nodes[].login'); do
+    # This line prints a message to the console
+    echo "Installations for $organization"
+    # This line fetches the installations for the current organization
+    # The 'gh api' command is used to make a request to the GitHub API
+    gh api "/orgs/$organization/installations"
+done


### PR DESCRIPTION
This pull request introduces a new Bash script, `app-installs.sh`, in the `api/bash` directory. The script is used to fetch the first 50 organizations of an enterprise and print the installations for each organization. It uses the GitHub CLI (`gh`) to execute a GraphQL query and make requests to the GitHub API.

Key changes:
* [`api/bash/app-installs.sh`](diffhunk://#diff-67922fd1739fbce0c1aa4039397a2164a84aa51084047bbc5ff21c9767f8dcd7R1-R34): Added a new Bash script that uses a GraphQL query to fetch the first 50 organizations of an enterprise. It iterates over each organization and prints the installations for that organization. The script uses the GitHub CLI (`gh`) to execute the GraphQL query and make requests to the GitHub API.