### PR TITLE
Creating new filtered SAML linked identity queries for GHEC non-EMUs

### DIFF
--- a/graphql/queries/enterprise-saml-identities-filtered-by-nameid.graphql
+++ b/graphql/queries/enterprise-saml-identities-filtered-by-nameid.graphql
@@ -1,44 +1,32 @@
-# You will need to replace <Enterprise Slug> and <SAML Name ID> with the actual GitHub enterprise slug and the SAML `NameID` value that you're searching stored external identities for in the GitHub enterprise.
+# You will need to replace <ENTERPRISE_SLUG> and <SAML Name ID> with the actual GitHub enterprise slug and the SAML `NameID` value that you're searching stored external identities for in the GitHub enterprise.
 # For GitHub Enterprise Cloud enterprises that have SAML configured at the enterprise level, this will query the stored SAML `nameId` external identity values in the GitHub enterprise, and if one is found that matches the value specified for `<SAML Name ID>`, it will print out the SAML `nameId` and GitHub username for that stored external identity.
+
+# Note that the query below will not tell you if the GitHub username/account associated with this linked identity is still a member of the enterprise. Enterprise owners can navigate to the Enterprise > People > Members UI and search for the user to determine this, or perform a different GraphQL query using the https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterprise object with the members(query:"<SAML Name ID>") filter. 
 
 # This query will not print out a user username (`login`) value if there is not a GitHub user account linked to this SAML identity. 
 # Pagination shouldn't be needed since there shouldn't be multiple entries in the enterprise that have the same SAML `NameID` or SCIM `userName`. However, for more information on pagination. There is also an example of pagination in simple-pagination-example.graphql.
 
 
 query EnterpriseIdentitiesBySAMLNameID {
-	enterprise(slug:"<Enterprise Slug>") {
-    name
-    members(query:"<SAML Name ID>", first:25) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        startCursor
-        endCursor
-      }
-      nodes{
-        ...on EnterpriseUserAccount {
-          id
-          login
-          createdAt
-        }
-      }
-    }
+ enterprise(slug: "<ENTERPRISE_SLUG>") {
     ownerInfo {
       samlIdentityProvider {
         externalIdentities(userName:"<SAML Name ID>", first: 25) {
           totalCount
+          edges {
+            node {
+              guid
+              samlIdentity {
+                nameId
+              }
+              user {
+                login
+              }
+            }
+          }
           pageInfo {
             hasNextPage
-            startCursor
             endCursor
-          }
-          nodes{
-            samlIdentity {
-              nameId
-            }
-            user {
-              login
-            }
           }
         }
       }

--- a/graphql/queries/enterprise-saml-identities-filtered-by-nameid.graphql
+++ b/graphql/queries/enterprise-saml-identities-filtered-by-nameid.graphql
@@ -1,0 +1,47 @@
+# You will need to replace <Enterprise Slug> and <SAML Name ID> with the actual GitHub enterprise slug and the SAML `NameID` value that you're searching stored external identities for in the GitHub enterprise.
+# For GitHub Enterprise Cloud enterprises that have SAML configured at the enterprise level, this will query the stored SAML `nameId` external identity values in the GitHub enterprise, and if one is found that matches the value specified for `<SAML Name ID>`, it will print out the SAML `nameId` and GitHub username for that stored external identity.
+
+# This query will not print out a user username (`login`) value if there is not a GitHub user account linked to this SAML identity. 
+# Pagination shouldn't be needed since there shouldn't be multiple entries in the enterprise that have the same SAML `NameID` or SCIM `userName`. However, for more information on pagination. There is also an example of pagination in simple-pagination-example.graphql.
+
+
+query EnterpriseIdentitiesBySAMLNameID {
+	enterprise(slug:"<Enterprise Slug>") {
+    name
+    members(query:"<SAML Name ID>", first:25) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        startCursor
+        endCursor
+      }
+      nodes{
+        ...on EnterpriseUserAccount {
+          id
+          login
+          createdAt
+        }
+      }
+    }
+    ownerInfo {
+      samlIdentityProvider {
+        externalIdentities(userName:"<SAML Name ID>", first: 25) {
+          totalCount
+          pageInfo {
+            hasNextPage
+            startCursor
+            endCursor
+          }
+          nodes{
+            samlIdentity {
+              nameId
+            }
+            user {
+              login
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/queries/org-saml-identities-filtered-by-nameid-username.graphql
+++ b/graphql/queries/org-saml-identities-filtered-by-nameid-username.graphql
@@ -2,7 +2,7 @@
 # For GitHub Enterprise Cloud organizations that have SAML configured at the organization level, this will query the stored SAML `nameId` and SCIM `userName` external identity values in the GitHub organization, and if one is found that matches the value specified for `<SAML Name ID>`, it will print out the SAML `nameId` and GitHub username for that stored external identity.
 
 # This query will not print out a user username (`login`) value if there is not a GitHub user account linked to this SAML identity. 
-# Pagination shouldn't be needed since there shouldn't be multiple entries that have the same SAML `NameID` or SCIM `userName`. However, for more information on pagination. There is also an example of pagination in simple-pagination-example.graphql.
+# Pagination shouldn't be needed since there shouldn't be multiple entries in the organization that have the same SAML `NameID` or SCIM `userName`. However, for more information on pagination. There is also an example of pagination in simple-pagination-example.graphql.
 
 query OrganizationIdentitiesBySAMLNameID {
   organization(login: <ORG_NAME>) {

--- a/graphql/queries/org-saml-identities-filtered-by-nameid-username.graphql
+++ b/graphql/queries/org-saml-identities-filtered-by-nameid-username.graphql
@@ -1,0 +1,27 @@
+# You will need to replace <ORG_NAME> and <SAML Name ID> with the actual GitHub organization name and the SAML `NameID` value that you're searching stored external identities for in the GitHub organization. 
+# For GitHub Enterprise Cloud organizations that have SAML configured at the organization level, this will query the stored SAML `nameId` and SCIM `userName` external identity values in the GitHub organization, and if one is found that matches the value specified for `<SAML Name ID>`, it will print out the SAML `nameId` and GitHub username for that stored external identity.
+
+# This query will not print out a user username (`login`) value if there is not a GitHub user account linked to this SAML identity. 
+# Pagination shouldn't be needed since there shouldn't be multiple entries that have the same SAML `NameID` or SCIM `userName`. However, for more information on pagination. There is also an example of pagination in simple-pagination-example.graphql.
+
+query OrganizationIdentitiesBySAMLNameID {
+  organization(login: <ORG_NAME>) {
+    samlIdentityProvider {
+      externalIdentities(userName:"<SAML Name ID>", first: 25) {
+        edges {
+          node {
+            samlIdentity {
+              nameId
+            }
+            user {
+              login
+            }
+          }
+        }
+        pageInfo {
+          endCursor
+        }
+      }
+    }
+  }
+}

--- a/graphql/queries/org-saml-identities-filtered-by-nameid-username.graphql
+++ b/graphql/queries/org-saml-identities-filtered-by-nameid-username.graphql
@@ -1,11 +1,13 @@
 # You will need to replace <ORG_NAME> and <SAML Name ID> with the actual GitHub organization name and the SAML `NameID` value that you're searching stored external identities for in the GitHub organization. 
 # For GitHub Enterprise Cloud organizations that have SAML configured at the organization level, this will query the stored SAML `nameId` and SCIM `userName` external identity values in the GitHub organization, and if one is found that matches the value specified for `<SAML Name ID>`, it will print out the SAML `nameId` and GitHub username for that stored external identity.
 
+# Note that the query below will not tell you if the GitHub username/account associated with this linked identity is still a member of the organization. Organization owners can navigate to the Organization > People > Members UI and search for the user to determine this.
+
 # This query will not print out a user username (`login`) value if there is not a GitHub user account linked to this SAML identity. 
 # Pagination shouldn't be needed since there shouldn't be multiple entries in the organization that have the same SAML `NameID` or SCIM `userName`. However, for more information on pagination. There is also an example of pagination in simple-pagination-example.graphql.
 
 query OrganizationIdentitiesBySAMLNameID {
-  organization(login: <ORG_NAME>) {
+  organization(login: "<ORG_NAME>") {
     samlIdentityProvider {
       externalIdentities(userName:"<SAML Name ID>", first: 25) {
         edges {


### PR DESCRIPTION
This PR creates two new sample GraphQL queries for GHEC non-EMUs:

- `org-saml-identities-filtered-by-nameid-username.graphql`
- `enterprise-saml-identities-filtered-by-nameid.graphql`

These queries can be used to find a stored external identity that has a specific SAML `nameId` or SCIM `userName` value. 

For example, this can help an enterprise or organization owner identity the root cause when a user receives the error message below (basically, it can show which GitHub user is already linked to the external identity in the organization/enterprise):

> Your GitHub user account [GitHub username] is currently unlinked. However, you are attempting to authenticate with your Identity Provider using [IdP user account] SAML identity which is already linked to a different GitHub user account in the [organization/enterprise]. Please reach out to one of your GitHub [organization/enterprise] owners for assistance.
