### PR TITLE
Add new GraphQL queries to list organization memberships for a user and list SCIM accounts for an EMU

### DIFF
--- a/graphql/queries/emu-list-scim-accounts.graphql
+++ b/graphql/queries/emu-list-scim-accounts.graphql
@@ -1,0 +1,26 @@
+# This GraphQL query can be used to generate a list of enterprise members and their SCIM account details in a GitHub Enterprise Cloud with Managed Users (EMU) enterprise account.
+#
+# Replace `ENTEPRISE_SLUG` with the slug of your enterprise. To get more than 10 members, you can adjust the "first" parameter.
+#
+# Note: the output will include suspended users (identified with their obfuscated account name), but it will not include personal user accounts that are not part of the EMU (Enterprise Managed Users) system.
+
+query ListAllEnterpriseUsers {
+  enterprise(slug: "ENTEPRISE_SLUG") {
+    ownerInfo {
+      samlIdentityProvider {
+        externalIdentities(first: 10) {
+          nodes {
+            user {
+              login
+              name
+            }
+            scimIdentity {
+              username
+              groups
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/queries/emu-list-scim-accounts.graphql
+++ b/graphql/queries/emu-list-scim-accounts.graphql
@@ -1,5 +1,6 @@
 # This GraphQL query can be used to generate a list of enterprise members and their SCIM account details in a GitHub Enterprise Cloud with Managed Users (EMU) enterprise account.
 #
+# Please ensure that your Personal Access Token (PAT) has the "read:enterprise" scope to access enterprise-level data.
 # Replace `ENTEPRISE_SLUG` with the slug of your enterprise. To get more than 10 members, you can adjust the "first" parameter.
 #
 # Note: the output will include suspended users (identified with their obfuscated account name), but it will not include personal user accounts that are not part of the EMU (Enterprise Managed Users) system.

--- a/graphql/queries/emu-list-scim-accounts.graphql
+++ b/graphql/queries/emu-list-scim-accounts.graphql
@@ -5,7 +5,12 @@
 # Note: the output will include suspended users (identified with their obfuscated account name), but it will not include personal user accounts that are not part of the EMU (Enterprise Managed Users) system.
 
 query ListAllEnterpriseUsers {
-  enterprise(slug: "ENTEPRISE_SLUG") {
+# Replace `ENTERPRISE_SLUG` with the slug of your enterprise. To get more than 10 members, you can adjust the "first" parameter.
+#
+# Note: the output will include suspended users (identified with their obfuscated account name), but it will not include personal user accounts that are not part of the EMU (Enterprise Managed Users) system.
+
+query ListAllEnterpriseUsers {
+  enterprise(slug: "ENTERPRISE_SLUG") {
     ownerInfo {
       samlIdentityProvider {
         externalIdentities(first: 10) {

--- a/graphql/queries/user-org-membership.graphql
+++ b/graphql/queries/user-org-membership.graphql
@@ -1,0 +1,15 @@
+# This GraphQL query can be used to generate a list of organizations a user belongs to on GitHub.com
+# replace GITHUB_LOGIN with the username that you would like to view
+#
+# Note: the organizations listed are only ones that the calling user is a member of. If the calling member is not part of any organizations that the searched user belong to, it will not be shown here.
+
+query GetUserOrganizations {
+  user(login: "GITHUB_LOGIN") {
+    organizations(first: 100) {
+      nodes {
+        organization_name: name
+        organization_slug: login
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This pull request adds two new GraphQL queries to the codebase, each designed to help retrieve important user and organization data from GitHub. The queries are well-documented and provide clear usage instructions for customizing the parameters.

## Outline

New GraphQL queries for account and membership information:

* Added `emu-list-scim-accounts.graphql` query to list enterprise members and their SCIM account details for GitHub Enterprise Cloud with Managed Users (EMU), including notes on usage and limitations.
* Added `user-org-membership.graphql` query to list organizations a specified user belongs to, with guidance on parameter replacement and output caveats.